### PR TITLE
feat(canvas): add tool size slider for brush and eraser

### DIFF
--- a/ios/Kiki/App/AppCoordinator.swift
+++ b/ios/Kiki/App/AppCoordinator.swift
@@ -31,6 +31,9 @@ final class AppCoordinator {
     var currentTool: DrawingTool = .brush {
         didSet { applyTool() }
     }
+    var toolSize: CGFloat = 5.0 {
+        didSet { applyTool() }
+    }
     var promptText = ""
     var selectedStylePreset: StylePreset = .photoreal
     var resultState: ResultState = .empty
@@ -208,9 +211,9 @@ final class AppCoordinator {
     private func applyTool() {
         switch currentTool {
         case .brush:
-            canvasViewModel.selectBrush()
+            canvasViewModel.selectBrush(width: toolSize)
         case .eraser:
-            canvasViewModel.selectEraser()
+            canvasViewModel.selectEraser(width: toolSize)
         }
     }
 }

--- a/ios/Kiki/Views/FloatingToolbar.swift
+++ b/ios/Kiki/Views/FloatingToolbar.swift
@@ -4,9 +4,23 @@ struct FloatingToolbar: View {
     @Environment(AppCoordinator.self) private var coordinator
 
     var body: some View {
+        @Bindable var coordinator = coordinator
+
         HStack(spacing: 12) {
             toolButton(icon: "pencil.tip", tool: .brush)
             toolButton(icon: "eraser", tool: .eraser)
+
+            Divider()
+                .frame(height: 24)
+
+            Slider(value: $coordinator.toolSize, in: 1...20, step: 1)
+                .frame(width: 120)
+
+            Text("\(Int(coordinator.toolSize))")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .monospacedDigit()
+                .frame(width: 20, alignment: .trailing)
 
             Divider()
                 .frame(height: 24)

--- a/ios/Packages/CanvasModule/Sources/CanvasModule/CanvasViewModel.swift
+++ b/ios/Packages/CanvasModule/Sources/CanvasModule/CanvasViewModel.swift
@@ -39,12 +39,12 @@ public final class CanvasViewModel {
         canvasView.tool = PKInkingTool(.pen, color: .black, width: 5)
     }
 
-    public func selectBrush() {
-        canvasView?.tool = PKInkingTool(.pen, color: .black, width: 5)
+    public func selectBrush(width: CGFloat = 5) {
+        canvasView?.tool = PKInkingTool(.pen, color: .black, width: width)
     }
 
-    public func selectEraser() {
-        canvasView?.tool = PKEraserTool(.bitmap)
+    public func selectEraser(width: CGFloat = 5) {
+        canvasView?.tool = PKEraserTool(.bitmap, width: width)
     }
 
     public func undo() {


### PR DESCRIPTION
Add a slider control to the floating toolbar that lets users adjust
the size of the currently selected drawing tool (brush or eraser).
Size range is 1-20pt with a numeric indicator.

- CanvasViewModel.selectBrush/selectEraser now accept a width parameter
- AppCoordinator.toolSize state drives tool size, re-applies on change
- FloatingToolbar shows a compact slider between tool and action buttons

https://claude.ai/code/session_01SKQb7zX29BCaqEVJHVZL1d