### PR TITLE
feat(canvas): add pinch-to-zoom and two-finger rotation

### DIFF
--- a/documents/decisions.md
+++ b/documents/decisions.md
@@ -14,6 +14,21 @@ Record implementation decisions here as they are made. Newest first. This preven
 
 ---
 
+### 2026-03-17 — Canvas zoom and rotation via RotatableCanvasContainer
+**Context:** Users need to zoom in for detail work and rotate the canvas to draw at comfortable angles.
+**Decision:** Wrap PKCanvasView in a RotatableCanvasContainer UIView. Zoom is handled by PKCanvasView's built-in UIScrollView (1x–5x). Rotation is handled by a UIRotationGestureRecognizer on the container, applying a CGAffineTransform to the parent while PKCanvasView's internal zoom transforms stay independent. UIKit automatically translates touch coordinates through the parent's transform, so drawing works at any rotation/zoom.
+**Alternatives considered:**
+- SwiftUI `.rotationEffect()` — breaks touch coordinate mapping for UIViewRepresentable
+- Direct transform on PKCanvasView — conflicts with UIScrollView's internal zoom transforms
+- CALayer transform3D — undocumented interaction with PencilKit touch handling
+**Consequences:**
+- Snapshot capture switched from `drawHierarchy` to `PKDrawing.image(from:scale:)` to capture full drawing regardless of zoom/scroll state
+- New file: `RotatableCanvasContainer.swift` in CanvasModule
+- Rotation snaps to 90° increments when released within ~8° threshold
+- Reset button appears in toolbar when canvas is zoomed or rotated
+
+---
+
 ### 2026-03-15 — Replace fal.ai with ComfyUI (Qwen-Image) on RunPod
 **Context:** fal-ai/scribble (SD 1.5 ControlNet) produced low-fidelity results with limited control. Needed higher quality generation with better sketch adherence and a model that supports more control types.
 **Decision:** Switch to Qwen-Image 20B (FP8) + InstantX ControlNet Union running on ComfyUI, hosted on a RunPod H100 80GB SXM GPU pod. Use AnyLine Lineart preprocessor for soft edge control from PencilKit sketches. Lightning LoRA V2.0 for 8-step generation.

--- a/ios/Kiki/Views/FloatingToolbar.swift
+++ b/ios/Kiki/Views/FloatingToolbar.swift
@@ -44,6 +44,17 @@ struct FloatingToolbar: View {
                 action: coordinator.clear,
                 disabled: coordinator.canvasViewModel.isEmpty
             )
+
+            if !coordinator.canvasViewModel.isDefaultTransform {
+                Divider()
+                    .frame(height: 24)
+
+                actionButton(
+                    icon: "arrow.counterclockwise",
+                    action: coordinator.canvasViewModel.resetViewTransform,
+                    disabled: false
+                )
+            }
         }
         .padding(.horizontal, 16)
         .padding(.vertical, 10)

--- a/ios/Packages/CanvasModule/Sources/CanvasModule/CanvasView.swift
+++ b/ios/Packages/CanvasModule/Sources/CanvasModule/CanvasView.swift
@@ -8,20 +8,26 @@ public struct CanvasView: UIViewRepresentable {
         self.viewModel = viewModel
     }
 
-    public func makeUIView(context: Context) -> PKCanvasView {
-        let canvasView = PKCanvasView()
-        viewModel.attach(canvasView)
+    public func makeUIView(context: Context) -> RotatableCanvasContainer {
+        let container = RotatableCanvasContainer()
+        let canvasView = container.canvasView
+        viewModel.attach(canvasView, container: container)
         canvasView.delegate = context.coordinator
-        return canvasView
+        container.onTransformChanged = { [weak viewModel] in
+            Task { @MainActor in
+                viewModel?.handleTransformChanged()
+            }
+        }
+        return container
     }
 
-    public func updateUIView(_ uiView: PKCanvasView, context: Context) {}
+    public func updateUIView(_ uiView: RotatableCanvasContainer, context: Context) {}
 
     public func makeCoordinator() -> Coordinator {
         Coordinator(viewModel: viewModel)
     }
 
-    public final class Coordinator: NSObject, PKCanvasViewDelegate {
+    public final class Coordinator: NSObject, PKCanvasViewDelegate, UIScrollViewDelegate {
         private let viewModel: CanvasViewModel
 
         init(viewModel: CanvasViewModel) {
@@ -31,6 +37,12 @@ public struct CanvasView: UIViewRepresentable {
         public func canvasViewDrawingDidChange(_ canvasView: PKCanvasView) {
             Task { @MainActor in
                 viewModel.handleDrawingChanged()
+            }
+        }
+
+        public func scrollViewDidZoom(_ scrollView: UIScrollView) {
+            Task { @MainActor in
+                viewModel.handleTransformChanged()
             }
         }
     }

--- a/ios/Packages/CanvasModule/Sources/CanvasModule/CanvasViewModel.swift
+++ b/ios/Packages/CanvasModule/Sources/CanvasModule/CanvasViewModel.swift
@@ -10,8 +10,15 @@ public final class CanvasViewModel {
     public private(set) var canUndo = false
     public private(set) var canRedo = false
     public private(set) var isEmpty = true
+    public private(set) var zoomScale: CGFloat = 1.0
+    public private(set) var rotation: CGFloat = 0
+
+    public var isDefaultTransform: Bool {
+        abs(rotation) < 0.01 && abs(zoomScale - 1.0) < 0.01
+    }
 
     private weak var canvasView: PKCanvasView?
+    private weak var container: RotatableCanvasContainer?
 
     public let canvasChanges: AsyncStream<SketchSnapshot>
     private let changesContinuation: AsyncStream<SketchSnapshot>.Continuation
@@ -30,13 +37,17 @@ public final class CanvasViewModel {
 
     // MARK: - Public API
 
-    func attach(_ canvasView: PKCanvasView) {
+    func attach(_ canvasView: PKCanvasView, container: RotatableCanvasContainer) {
         self.canvasView = canvasView
+        self.container = container
         canvasView.drawingPolicy = .anyInput
         canvasView.overrideUserInterfaceStyle = .light
         canvasView.backgroundColor = .white
         canvasView.isOpaque = true
         canvasView.tool = PKInkingTool(.pen, color: .black, width: 5)
+        canvasView.minimumZoomScale = 1.0
+        canvasView.maximumZoomScale = 5.0
+        canvasView.bouncesZoom = true
     }
 
     public func selectBrush(width: CGFloat = 5) {
@@ -59,6 +70,7 @@ public final class CanvasViewModel {
 
     public func clear() {
         canvasView?.drawing = PKDrawing()
+        resetViewTransform()
         updateState()
         changesContinuation.yield(SketchSnapshot(
             image: UIImage(),
@@ -67,16 +79,26 @@ public final class CanvasViewModel {
         ))
     }
 
+    public func resetViewTransform() {
+        container?.resetTransform()
+        zoomScale = 1.0
+        rotation = 0
+    }
+
     public func captureSnapshot() -> SketchSnapshot? {
         guard let canvasView else { return nil }
         let drawing = canvasView.drawing
         guard !drawing.strokes.isEmpty else { return nil }
 
-        // Render the canvas view as-is (white background + strokes), rather than
-        // extracting the drawing separately which loses strokes during compositing.
-        let renderer = UIGraphicsImageRenderer(bounds: canvasView.bounds)
-        let image = renderer.image { _ in
-            canvasView.drawHierarchy(in: canvasView.bounds, afterScreenUpdates: true)
+        // Use PKDrawing.image() to capture the full drawing regardless of zoom/scroll state.
+        // drawHierarchy would only capture the visible viewport when zoomed in.
+        let fullBounds = CGRect(origin: .zero, size: canvasView.frame.size)
+        let renderer = UIGraphicsImageRenderer(bounds: fullBounds)
+        let image = renderer.image { ctx in
+            UIColor.white.setFill()
+            ctx.fill(fullBounds)
+            let drawingImage = drawing.image(from: fullBounds, scale: 1.0)
+            drawingImage.draw(in: fullBounds)
         }
 
         return SketchSnapshot(
@@ -97,6 +119,11 @@ public final class CanvasViewModel {
             strokeCount: canvasView?.drawing.strokes.count ?? 0,
             bounds: canvasView?.drawing.bounds ?? .zero
         ))
+    }
+
+    func handleTransformChanged() {
+        zoomScale = canvasView?.zoomScale ?? 1.0
+        rotation = container?.rotation ?? 0
     }
 
     // MARK: - Private

--- a/ios/Packages/CanvasModule/Sources/CanvasModule/RotatableCanvasContainer.swift
+++ b/ios/Packages/CanvasModule/Sources/CanvasModule/RotatableCanvasContainer.swift
@@ -1,0 +1,89 @@
+import UIKit
+import PencilKit
+
+public final class RotatableCanvasContainer: UIView, UIGestureRecognizerDelegate {
+
+    // MARK: - Public
+
+    public let canvasView = PKCanvasView()
+    public private(set) var rotation: CGFloat = 0
+    public var onTransformChanged: (() -> Void)?
+
+    // MARK: - Private
+
+    private static let snapThreshold: CGFloat = 0.15 // ~8.6 degrees
+
+    // MARK: - Init
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        setup()
+    }
+
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+        setup()
+    }
+
+    // MARK: - Setup
+
+    private func setup() {
+        canvasView.translatesAutoresizingMaskIntoConstraints = false
+        addSubview(canvasView)
+        NSLayoutConstraint.activate([
+            canvasView.topAnchor.constraint(equalTo: topAnchor),
+            canvasView.leadingAnchor.constraint(equalTo: leadingAnchor),
+            canvasView.trailingAnchor.constraint(equalTo: trailingAnchor),
+            canvasView.bottomAnchor.constraint(equalTo: bottomAnchor),
+        ])
+
+        let rotationGesture = UIRotationGestureRecognizer(target: self, action: #selector(handleRotation(_:)))
+        rotationGesture.delegate = self
+        addGestureRecognizer(rotationGesture)
+    }
+
+    // MARK: - Gesture Handling
+
+    @objc private func handleRotation(_ gesture: UIRotationGestureRecognizer) {
+        switch gesture.state {
+        case .changed:
+            rotation += gesture.rotation
+            gesture.rotation = 0
+            transform = CGAffineTransform(rotationAngle: rotation)
+            onTransformChanged?()
+
+        case .ended, .cancelled:
+            rotation += gesture.rotation
+            transform = CGAffineTransform(rotationAngle: rotation)
+            // Snap to nearest 90 degrees if within threshold
+            let nearestQuarter = (rotation / (.pi / 2)).rounded() * (.pi / 2)
+            if abs(rotation - nearestQuarter) < Self.snapThreshold {
+                rotation = nearestQuarter
+                UIView.animate(withDuration: 0.2) {
+                    self.transform = CGAffineTransform(rotationAngle: self.rotation)
+                }
+            }
+            onTransformChanged?()
+
+        default:
+            break
+        }
+    }
+
+    public func gestureRecognizer(
+        _ gestureRecognizer: UIGestureRecognizer,
+        shouldRecognizeSimultaneouslyWith other: UIGestureRecognizer
+    ) -> Bool {
+        gestureRecognizer is UIRotationGestureRecognizer
+    }
+
+    // MARK: - Public API
+
+    public func resetTransform() {
+        rotation = 0
+        UIView.animate(withDuration: 0.3) {
+            self.transform = .identity
+            self.canvasView.zoomScale = 1.0
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Wrap PKCanvasView in a RotatableCanvasContainer UIView enabling pinch-to-zoom (1x–5x) and two-finger rotation with 90° snapping
- Fix snapshot capture to use `PKDrawing.image(from:scale:)` so it always captures the full drawing regardless of zoom/scroll state
- Add reset view button to FloatingToolbar (appears when canvas is zoomed or rotated)

## Test plan
- [ ] Two-finger pinch zooms canvas; two-finger rotate rotates; simultaneous pinch+rotate works
- [ ] Single-finger + Apple Pencil drawing works at all zoom/rotation levels
- [ ] Draw → zoom to 3x + rotate 45° → trigger generation → verify full unrotated drawing is captured
- [ ] Tap reset button → canvas animates to 1x zoom, 0° rotation, button disappears
- [ ] Rotate near 90° → snaps to exact 90° on release
- [ ] Clear while zoomed/rotated → resets to default view
- [ ] Undo/redo while zoomed/rotated → view transform preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)