### PR TITLE
fix(canvas): use visual transform for zoom instead of UIScrollView

### DIFF
--- a/documents/decisions.md
+++ b/documents/decisions.md
@@ -16,15 +16,16 @@ Record implementation decisions here as they are made. Newest first. This preven
 
 ### 2026-03-17 — Canvas zoom and rotation via RotatableCanvasContainer
 **Context:** Users need to zoom in for detail work and rotate the canvas to draw at comfortable angles.
-**Decision:** Wrap PKCanvasView in a RotatableCanvasContainer UIView. Zoom is handled by PKCanvasView's built-in UIScrollView (1x–5x). Rotation is handled by a UIRotationGestureRecognizer on the container, applying a CGAffineTransform to the parent while PKCanvasView's internal zoom transforms stay independent. UIKit automatically translates touch coordinates through the parent's transform, so drawing works at any rotation/zoom.
+**Decision:** Wrap PKCanvasView in a RotatableCanvasContainer with a three-level view hierarchy: container (SwiftUI-managed, no transform) → transformView (receives combined CGAffineTransform for scale + rotation) → PKCanvasView (drawing only). Zoom and rotation are handled by UIPinchGestureRecognizer and UIRotationGestureRecognizer on the container, applied as a single combined transform on the intermediate view. UIKit automatically translates touch coordinates through the parent's transform, so drawing works at any scale/rotation.
 **Alternatives considered:**
 - SwiftUI `.rotationEffect()` — breaks touch coordinate mapping for UIViewRepresentable
-- Direct transform on PKCanvasView — conflicts with UIScrollView's internal zoom transforms
+- Transform on the UIViewRepresentable root view — SwiftUI re-layouts fight the transform, squishing the canvas
+- PKCanvasView's built-in UIScrollView zoom — zooms content inside a fixed frame with scroll bars, not the whole canvas visually
 - CALayer transform3D — undocumented interaction with PencilKit touch handling
 **Consequences:**
-- Snapshot capture switched from `drawHierarchy` to `PKDrawing.image(from:scale:)` to capture full drawing regardless of zoom/scroll state
+- Snapshot capture switched from `drawHierarchy` to `PKDrawing.image(from:scale:)` to capture full drawing regardless of visual transform
 - New file: `RotatableCanvasContainer.swift` in CanvasModule
-- Rotation snaps to 90° increments when released within ~8° threshold
+- Rotation snaps to 90° increments when released within ~8° threshold; scale clamped to 0.5x–5x
 - Reset button appears in toolbar when canvas is zoomed or rotated
 
 ---

--- a/ios/Packages/CanvasModule/Sources/CanvasModule/CanvasView.swift
+++ b/ios/Packages/CanvasModule/Sources/CanvasModule/CanvasView.swift
@@ -27,7 +27,7 @@ public struct CanvasView: UIViewRepresentable {
         Coordinator(viewModel: viewModel)
     }
 
-    public final class Coordinator: NSObject, PKCanvasViewDelegate, UIScrollViewDelegate {
+    public final class Coordinator: NSObject, PKCanvasViewDelegate {
         private let viewModel: CanvasViewModel
 
         init(viewModel: CanvasViewModel) {
@@ -37,12 +37,6 @@ public struct CanvasView: UIViewRepresentable {
         public func canvasViewDrawingDidChange(_ canvasView: PKCanvasView) {
             Task { @MainActor in
                 viewModel.handleDrawingChanged()
-            }
-        }
-
-        public func scrollViewDidZoom(_ scrollView: UIScrollView) {
-            Task { @MainActor in
-                viewModel.handleTransformChanged()
             }
         }
     }

--- a/ios/Packages/CanvasModule/Sources/CanvasModule/CanvasViewModel.swift
+++ b/ios/Packages/CanvasModule/Sources/CanvasModule/CanvasViewModel.swift
@@ -10,11 +10,11 @@ public final class CanvasViewModel {
     public private(set) var canUndo = false
     public private(set) var canRedo = false
     public private(set) var isEmpty = true
-    public private(set) var zoomScale: CGFloat = 1.0
+    public private(set) var scale: CGFloat = 1.0
     public private(set) var rotation: CGFloat = 0
 
     public var isDefaultTransform: Bool {
-        abs(rotation) < 0.01 && abs(zoomScale - 1.0) < 0.01
+        abs(rotation) < 0.01 && abs(scale - 1.0) < 0.01
     }
 
     private weak var canvasView: PKCanvasView?
@@ -45,9 +45,8 @@ public final class CanvasViewModel {
         canvasView.backgroundColor = .white
         canvasView.isOpaque = true
         canvasView.tool = PKInkingTool(.pen, color: .black, width: 5)
-        canvasView.minimumZoomScale = 1.0
-        canvasView.maximumZoomScale = 5.0
-        canvasView.bouncesZoom = true
+        canvasView.showsHorizontalScrollIndicator = false
+        canvasView.showsVerticalScrollIndicator = false
     }
 
     public func selectBrush(width: CGFloat = 5) {
@@ -81,7 +80,7 @@ public final class CanvasViewModel {
 
     public func resetViewTransform() {
         container?.resetTransform()
-        zoomScale = 1.0
+        scale = 1.0
         rotation = 0
     }
 
@@ -122,7 +121,7 @@ public final class CanvasViewModel {
     }
 
     func handleTransformChanged() {
-        zoomScale = canvasView?.zoomScale ?? 1.0
+        scale = container?.scale ?? 1.0
         rotation = container?.rotation ?? 0
     }
 

--- a/ios/Packages/CanvasModule/Sources/CanvasModule/RotatableCanvasContainer.swift
+++ b/ios/Packages/CanvasModule/Sources/CanvasModule/RotatableCanvasContainer.swift
@@ -7,11 +7,17 @@ public final class RotatableCanvasContainer: UIView, UIGestureRecognizerDelegate
 
     public let canvasView = PKCanvasView()
     public private(set) var rotation: CGFloat = 0
+    public private(set) var scale: CGFloat = 1.0
     public var onTransformChanged: (() -> Void)?
 
     // MARK: - Private
 
+    /// Intermediate view that receives the combined scale + rotation transform.
+    /// The container itself has no transform (SwiftUI manages its frame).
+    private let transformView = UIView()
     private static let snapThreshold: CGFloat = 0.15 // ~8.6 degrees
+    private static let minScale: CGFloat = 0.5
+    private static let maxScale: CGFloat = 5.0
 
     // MARK: - Init
 
@@ -28,18 +34,27 @@ public final class RotatableCanvasContainer: UIView, UIGestureRecognizerDelegate
     // MARK: - Setup
 
     private func setup() {
-        canvasView.translatesAutoresizingMaskIntoConstraints = false
-        addSubview(canvasView)
-        NSLayoutConstraint.activate([
-            canvasView.topAnchor.constraint(equalTo: topAnchor),
-            canvasView.leadingAnchor.constraint(equalTo: leadingAnchor),
-            canvasView.trailingAnchor.constraint(equalTo: trailingAnchor),
-            canvasView.bottomAnchor.constraint(equalTo: bottomAnchor),
-        ])
+        clipsToBounds = true
+        backgroundColor = .black
+
+        // transformView fills container — use autoresizing so it tracks size
+        // changes without Auto Layout fighting the transform.
+        transformView.frame = bounds
+        transformView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
+        addSubview(transformView)
+
+        // canvasView fills transformView
+        canvasView.frame = transformView.bounds
+        canvasView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
+        transformView.addSubview(canvasView)
 
         let rotationGesture = UIRotationGestureRecognizer(target: self, action: #selector(handleRotation(_:)))
         rotationGesture.delegate = self
         addGestureRecognizer(rotationGesture)
+
+        let pinchGesture = UIPinchGestureRecognizer(target: self, action: #selector(handlePinch(_:)))
+        pinchGesture.delegate = self
+        addGestureRecognizer(pinchGesture)
     }
 
     // MARK: - Gesture Handling
@@ -49,20 +64,37 @@ public final class RotatableCanvasContainer: UIView, UIGestureRecognizerDelegate
         case .changed:
             rotation += gesture.rotation
             gesture.rotation = 0
-            transform = CGAffineTransform(rotationAngle: rotation)
+            applyTransform()
             onTransformChanged?()
 
         case .ended, .cancelled:
             rotation += gesture.rotation
-            transform = CGAffineTransform(rotationAngle: rotation)
             // Snap to nearest 90 degrees if within threshold
             let nearestQuarter = (rotation / (.pi / 2)).rounded() * (.pi / 2)
             if abs(rotation - nearestQuarter) < Self.snapThreshold {
                 rotation = nearestQuarter
-                UIView.animate(withDuration: 0.2) {
-                    self.transform = CGAffineTransform(rotationAngle: self.rotation)
-                }
+                UIView.animate(withDuration: 0.2) { self.applyTransform() }
+            } else {
+                applyTransform()
             }
+            onTransformChanged?()
+
+        default:
+            break
+        }
+    }
+
+    @objc private func handlePinch(_ gesture: UIPinchGestureRecognizer) {
+        switch gesture.state {
+        case .changed:
+            scale = (scale * gesture.scale).clamped(to: Self.minScale...Self.maxScale)
+            gesture.scale = 1.0
+            applyTransform()
+            onTransformChanged?()
+
+        case .ended, .cancelled:
+            scale = (scale * gesture.scale).clamped(to: Self.minScale...Self.maxScale)
+            applyTransform()
             onTransformChanged?()
 
         default:
@@ -74,16 +106,34 @@ public final class RotatableCanvasContainer: UIView, UIGestureRecognizerDelegate
         _ gestureRecognizer: UIGestureRecognizer,
         shouldRecognizeSimultaneouslyWith other: UIGestureRecognizer
     ) -> Bool {
-        gestureRecognizer is UIRotationGestureRecognizer
+        // Allow pinch and rotation to work simultaneously
+        let dominated = gestureRecognizer is UIRotationGestureRecognizer
+            || gestureRecognizer is UIPinchGestureRecognizer
+        let dominating = other is UIRotationGestureRecognizer
+            || other is UIPinchGestureRecognizer
+        return dominated && dominating
     }
 
     // MARK: - Public API
 
     public func resetTransform() {
         rotation = 0
-        UIView.animate(withDuration: 0.3) {
-            self.transform = .identity
-            self.canvasView.zoomScale = 1.0
-        }
+        scale = 1.0
+        UIView.animate(withDuration: 0.3) { self.applyTransform() }
+    }
+
+    // MARK: - Private
+
+    private func applyTransform() {
+        transformView.transform = CGAffineTransform(rotationAngle: rotation)
+            .scaledBy(x: scale, y: scale)
+    }
+}
+
+// MARK: - Comparable clamping
+
+private extension Comparable {
+    func clamped(to range: ClosedRange<Self>) -> Self {
+        min(max(self, range.lowerBound), range.upperBound)
     }
 }


### PR DESCRIPTION
## Summary
- Replace UIScrollView zoom with UIPinchGestureRecognizer — the whole canvas now visually scales instead of scrolling content inside a fixed frame with scroll bars
- Fix layout squishing by moving the transform to an intermediate `transformView` inside the container (SwiftUI was fighting the transform on the root UIViewRepresentable view)
- Combine scale + rotation into a single `CGAffineTransform` on the intermediate view
- Hide PKCanvasView scroll indicators

## Test plan
- [ ] Pinch to zoom scales the entire white canvas, no scroll bars
- [ ] Simultaneous pinch + rotate works smoothly
- [ ] Drawing works correctly at any scale/rotation
- [ ] Reset button returns to 1x scale, 0° rotation
- [ ] Clear resets transform
- [ ] Snapshot captures full unrotated drawing regardless of transform

🤖 Generated with [Claude Code](https://claude.com/claude-code)