### PR TITLE
fix(canvas): use bounds instead of frame for snapshot capture under zoom/rotation

### DIFF
--- a/backend/src/modules/providers/comfyui.ts
+++ b/backend/src/modules/providers/comfyui.ts
@@ -114,10 +114,10 @@ export class ComfyUIAdapter implements ProviderAdapter {
 
   private async uploadImage(baseUrl: string, base64: string): Promise<string> {
     const buffer = Buffer.from(base64, 'base64');
-    const blob = new Blob([buffer], { type: 'image/png' });
+    const blob = new Blob([buffer], { type: 'image/jpeg' });
 
     const formData = new FormData();
-    formData.append('image', blob, `sketch_${Date.now()}.png`);
+    formData.append('image', blob, `sketch_${Date.now()}.jpg`);
     formData.append('overwrite', 'true');
 
     const response = await fetch(`${baseUrl}/upload/image`, {

--- a/ios/Packages/CanvasModule/Sources/CanvasModule/CanvasViewModel.swift
+++ b/ios/Packages/CanvasModule/Sources/CanvasModule/CanvasViewModel.swift
@@ -89,15 +89,20 @@ public final class CanvasViewModel {
         let drawing = canvasView.drawing
         guard !drawing.strokes.isEmpty else { return nil }
 
-        // Use PKDrawing.image() to capture the full drawing regardless of zoom/scroll state.
-        // drawHierarchy would only capture the visible viewport when zoomed in.
-        let fullBounds = CGRect(origin: .zero, size: canvasView.frame.size)
-        let renderer = UIGraphicsImageRenderer(bounds: fullBounds)
+        // Use bounds (not frame) — frame is undefined when an ancestor view has
+        // a non-identity CGAffineTransform (zoom/rotation on transformView).
+        // For PKCanvasView (a UIScrollView), bounds.origin == contentOffset,
+        // so this also captures the correct region if scrolled.
+        let captureRect = canvasView.bounds
+        let outputSize = captureRect.size
+        guard outputSize.width > 0, outputSize.height > 0 else { return nil }
+
+        let renderer = UIGraphicsImageRenderer(size: outputSize)
         let image = renderer.image { ctx in
             UIColor.white.setFill()
-            ctx.fill(fullBounds)
-            let drawingImage = drawing.image(from: fullBounds, scale: 1.0)
-            drawingImage.draw(in: fullBounds)
+            ctx.fill(CGRect(origin: .zero, size: outputSize))
+            let drawingImage = drawing.image(from: captureRect, scale: 1.0)
+            drawingImage.draw(in: CGRect(origin: .zero, size: outputSize))
         }
 
         return SketchSnapshot(

--- a/ios/Packages/CanvasModule/Sources/CanvasModule/RotatableCanvasContainer.swift
+++ b/ios/Packages/CanvasModule/Sources/CanvasModule/RotatableCanvasContainer.swift
@@ -46,6 +46,7 @@ public final class RotatableCanvasContainer: UIView, UIGestureRecognizerDelegate
         // canvasView fills transformView
         canvasView.frame = transformView.bounds
         canvasView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
+        canvasView.isScrollEnabled = false // Zoom/rotation handled by container; prevent contentOffset drift
         transformView.addSubview(canvasView)
 
         let rotationGesture = UIRotationGestureRecognizer(target: self, action: #selector(handleRotation(_:)))


### PR DESCRIPTION
After adding pinch-to-zoom and rotation, canvasView.frame became unreliable
because its ancestor (transformView) has a non-identity CGAffineTransform.
Apple docs state frame is undefined in this case, leading to wrong-sized or
zero-sized captures — effectively sending a blank image to ControlNet.

Three fixes:
- Use canvasView.bounds (transform-independent) for snapshot capture rect
- Disable PKCanvasView's built-in scroll to prevent contentOffset drift
- Fix JPEG/PNG MIME type mismatch in backend ComfyUI image upload

https://claude.ai/code/session_01MTPViknvLcwaEucayLoJvd