### PR TITLE
Refactor generation pipeline, add manual/auto mode toggle, fix bugs

### DIFF
--- a/ios/Kiki/App/AppCoordinator.swift
+++ b/ios/Kiki/App/AppCoordinator.swift
@@ -133,8 +133,9 @@ final class AppCoordinator {
 
                 guard !Task.isCancelled, currentRequestId == requestId else { return }
 
-                // Empty canvas — no generation needed
+                // Empty canvas — no generation needed, restore previous state
                 guard let output else {
+                    resultState = lastSuccessfulImage.map { .preview(image: $0) } ?? .empty
                     isGenerating = false
                     return
                 }

--- a/ios/Kiki/App/AppCoordinator.swift
+++ b/ios/Kiki/App/AppCoordinator.swift
@@ -112,8 +112,6 @@ final class AppCoordinator {
         generationTask?.cancel()
 
         generationTask = Task {
-            defer { isGenerating = false }
-
             let input = GenerationPipeline.Input(
                 sessionId: sessionId,
                 requestId: requestId,
@@ -136,7 +134,10 @@ final class AppCoordinator {
                 guard !Task.isCancelled, currentRequestId == requestId else { return }
 
                 // Empty canvas — no generation needed
-                guard let output else { return }
+                guard let output else {
+                    isGenerating = false
+                    return
+                }
 
                 lastSuccessfulImage = output.image
                 resultState = .preview(image: output.image)
@@ -145,16 +146,18 @@ final class AppCoordinator {
                     advancedParameters.seed = seed
                 }
             } catch is CancellationError {
-                // Silently ignore cancellation
+                return
             } catch {
-                guard !Task.isCancelled, currentRequestId == requestId else { return }
+                if Task.isCancelled { return }
+                guard currentRequestId == requestId else { return }
                 resultState = .error(
                     message: mapErrorMessage(error),
                     previousImage: lastSuccessfulImage
                 )
             }
 
-            // Auto-retrigger if canvas changed during generation
+            // Clear isGenerating before retrigger so generate() doesn't hit the in-flight guard
+            isGenerating = false
             if hasUnsavedChanges {
                 generate()
             }

--- a/ios/Kiki/App/AppCoordinator.swift
+++ b/ios/Kiki/App/AppCoordinator.swift
@@ -40,10 +40,19 @@ final class AppCoordinator {
     var advancedParameters = AdvancedParameters()
     var isSeedLocked = false
 
+    // MARK: - Generation Mode
+
+    var triggerMode: GenerationTriggerMode = .auto {
+        didSet { UserDefaults.standard.set(triggerMode.rawValue, forKey: "generationTriggerMode") }
+    }
+
+    /// True when the canvas has changed since the last generation started.
+    private(set) var hasUnsavedChanges = false
+
     // MARK: - Modules
 
     let canvasViewModel = CanvasViewModel()
-    private let apiClient: APIClient
+    private let pipeline: GenerationPipeline
 
     // MARK: - Generation State
 
@@ -51,15 +60,22 @@ final class AppCoordinator {
     private var currentRequestId: UUID?
     private var lastSuccessfulImage: UIImage?
 
-    private var isCanvasDirty = false
     private(set) var isGenerating = false
+    private var generationTask: Task<Void, Never>?
     private var debounceTask: Task<Void, Never>?
     private var canvasObservationTask: Task<Void, Never>?
 
     // MARK: - Lifecycle
 
     init(backendURL: URL = URL(string: "https://kiki-backend-production-eb81.up.railway.app")!) {
-        self.apiClient = APIClient(baseURL: backendURL)
+        let apiClient = APIClient(baseURL: backendURL)
+        self.pipeline = GenerationPipeline(apiClient: apiClient)
+
+        if let stored = UserDefaults.standard.string(forKey: "generationTriggerMode"),
+           let mode = GenerationTriggerMode(rawValue: stored) {
+            self.triggerMode = mode
+        }
+
         applyTool()
         startObservingCanvas()
     }
@@ -76,133 +92,70 @@ final class AppCoordinator {
 
     func clear() {
         canvasViewModel.clear()
-        isCanvasDirty = false
+        hasUnsavedChanges = false
     }
 
     /// Triggers a preview generation from the current canvas state.
     func generate() {
-        // If a request is already in-flight, mark dirty so it auto-retriggers on completion.
-        // This prevents concurrent requests from piling up on the single GPU.
+        // Serial queue: if already generating, mark dirty for auto-retrigger on completion.
         if isGenerating {
-            isCanvasDirty = true
+            hasUnsavedChanges = true
             return
         }
 
         let requestId = UUID()
         currentRequestId = requestId
-        isCanvasDirty = false
+        hasUnsavedChanges = false
         isGenerating = true
 
-        Task {
-            defer { if isGenerating { isGenerating = false } }
+        // Cancel any prior generation task (latest-request-wins)
+        generationTask?.cancel()
 
-            var durations: [GenerationPhase: TimeInterval] = [:]
-            var phaseStart = Date()
+        generationTask = Task {
+            defer { isGenerating = false }
 
-            // Phase: preparing (snapshot + JPEG encoding)
-            resultState = .generating(
-                progress: GenerationProgress(currentPhase: .preparing, phaseStartedAt: phaseStart),
-                previousImage: lastSuccessfulImage
-            )
-
-            // Capture snapshot
-            guard let snapshot = canvasViewModel.captureSnapshot(),
-                  !snapshot.isEmpty else {
-                return
-            }
-            let img = snapshot.image
-
-            // Convert directly to JPEG (canvas capture already includes white background)
-            guard let jpegData = img.jpegData(compressionQuality: 0.85) else {
-                resultState = .error(
-                    message: "Failed to process sketch",
-                    previousImage: lastSuccessfulImage
-                )
-                return
-            }
-            print("[Generate] JPEG: \(jpegData.count) bytes, image: \(img.size)")
-
-            guard !Task.isCancelled, currentRequestId == requestId else { return }
-
-            // Phase: uploading (full network round-trip)
-            durations[.preparing] = Date().timeIntervalSince(phaseStart)
-            phaseStart = Date()
-            resultState = .generating(
-                progress: GenerationProgress(currentPhase: .uploading, phaseStartedAt: phaseStart, durations: durations),
-                previousImage: lastSuccessfulImage
-            )
-
-            // Send to backend
-            let base64 = jpegData.base64EncodedString()
-            let request = GenerateRequest(
+            let input = GenerationPipeline.Input(
                 sessionId: sessionId,
                 requestId: requestId,
-                mode: .preview,
+                canvasViewModel: canvasViewModel,
                 prompt: promptText.isEmpty ? nil : promptText,
                 stylePreset: selectedStylePreset.apiKey,
-                sketchImageBase64: base64,
-                advancedParameters: advancedParameters.isDefault ? nil : advancedParameters
+                advancedParameters: advancedParameters.isDefault ? nil : advancedParameters,
+                isSeedLocked: isSeedLocked
             )
 
             do {
-                let response = try await apiClient.generate(request)
-                print("[Generate] Response: status=\(response.status), imageURL=\(response.imageURL?.absoluteString ?? "nil"), inputImageURL=\(response.inputImageURL?.absoluteString ?? "nil"), lineartImageURL=\(response.lineartImageURL?.absoluteString ?? "nil")")
-
-                guard !Task.isCancelled, currentRequestId == requestId else { return }
-
-                if response.status == .completed, let imageURL = response.imageURL {
-                    if isSeedLocked, let seed = response.seed {
-                        advancedParameters.seed = seed
-                    }
-
-                    // Phase: downloading
-                    durations[.uploading] = Date().timeIntervalSince(phaseStart)
-                    phaseStart = Date()
+                let output = try await pipeline.run(input: input) { [weak self] phase, durations in
+                    guard let self, currentRequestId == requestId else { return }
                     resultState = .generating(
-                        progress: GenerationProgress(currentPhase: .downloading, phaseStartedAt: phaseStart, durations: durations),
-                        previousImage: lastSuccessfulImage
-                    )
-
-                    let (data, _) = try await URLSession.shared.data(from: imageURL)
-                    guard let image = UIImage(data: data) else {
-                        resultState = .error(message: "Image decode failed — \(data.count) bytes from \(imageURL.lastPathComponent)", previousImage: lastSuccessfulImage)
-                        return
-                    }
-                    guard !Task.isCancelled, currentRequestId == requestId else { return }
-                    lastSuccessfulImage = image
-                    resultState = .preview(image: image)
-                } else {
-                    resultState = .error(
-                        message: "Generation failed — status: \(response.status), imageURL: \(response.imageURL?.absoluteString ?? "nil")",
+                        progress: GenerationProgress(currentPhase: phase, durations: durations),
                         previousImage: lastSuccessfulImage
                     )
                 }
+
+                guard !Task.isCancelled, currentRequestId == requestId else { return }
+
+                // Empty canvas — no generation needed
+                guard let output else { return }
+
+                lastSuccessfulImage = output.image
+                resultState = .preview(image: output.image)
+
+                if isSeedLocked, let seed = output.seed {
+                    advancedParameters.seed = seed
+                }
             } catch is CancellationError {
                 // Silently ignore cancellation
-            } catch let error as GenerationError {
-                guard !Task.isCancelled, currentRequestId == requestId else { return }
-                resultState = .error(
-                    message: error.userMessage,
-                    previousImage: lastSuccessfulImage
-                )
-            } catch let urlError as URLError {
-                guard !Task.isCancelled, currentRequestId == requestId else { return }
-                resultState = .error(
-                    message: "Network error: \(urlError.localizedDescription) (code \(urlError.code.rawValue))",
-                    previousImage: lastSuccessfulImage
-                )
             } catch {
                 guard !Task.isCancelled, currentRequestId == requestId else { return }
                 resultState = .error(
-                    message: "\(type(of: error)): \(error.localizedDescription)",
+                    message: mapErrorMessage(error),
                     previousImage: lastSuccessfulImage
                 )
             }
 
-            // Auto-retrigger if canvas changed during generation.
-            // Must clear isGenerating first so generate() doesn't hit the in-flight guard.
-            isGenerating = false
-            if isCanvasDirty {
+            // Auto-retrigger if canvas changed during generation
+            if hasUnsavedChanges {
                 generate()
             }
         }
@@ -215,12 +168,13 @@ final class AppCoordinator {
             guard let self else { return }
             for await _ in canvasViewModel.canvasChanges {
                 guard !Task.isCancelled else { return }
-                isCanvasDirty = true
+                hasUnsavedChanges = true
 
-                // Cancel previous debounce timer
+                // In manual mode, just mark dirty — don't auto-generate
+                guard triggerMode == .auto else { continue }
+
+                // Auto mode: debounce then generate after 1.5s of no drawing
                 debounceTask?.cancel()
-
-                // Start new debounce — generate after 1.5s of no drawing
                 debounceTask = Task { [weak self] in
                     try? await Task.sleep(for: .seconds(1.5))
                     guard !Task.isCancelled, let self else { return }
@@ -240,6 +194,19 @@ final class AppCoordinator {
             canvasViewModel.selectBrush(width: toolSize)
         case .eraser:
             canvasViewModel.selectEraser(width: toolSize)
+        }
+    }
+
+    private func mapErrorMessage(_ error: Error) -> String {
+        switch error {
+        case let pipelineError as PipelineError:
+            return pipelineError.userMessage
+        case let generationError as GenerationError:
+            return generationError.userMessage
+        case let urlError as URLError:
+            return "Network error: \(urlError.localizedDescription) (code \(urlError.code.rawValue))"
+        default:
+            return "\(type(of: error)): \(error.localizedDescription)"
         }
     }
 }

--- a/ios/Kiki/App/AppCoordinator.swift
+++ b/ios/Kiki/App/AppCoordinator.swift
@@ -172,6 +172,9 @@ final class AppCoordinator {
             guard let self else { return }
             for await _ in canvasViewModel.canvasChanges {
                 guard !Task.isCancelled else { return }
+
+                // Don't mark dirty for empty canvas (e.g. after clear or erasing last stroke)
+                guard !canvasViewModel.isEmpty else { continue }
                 hasUnsavedChanges = true
 
                 // In manual mode, just mark dirty — don't auto-generate

--- a/ios/Kiki/App/GenerationPipeline.swift
+++ b/ios/Kiki/App/GenerationPipeline.swift
@@ -1,0 +1,122 @@
+import UIKit
+import CanvasModule
+import NetworkModule
+import ResultModule
+
+@MainActor
+final class GenerationPipeline {
+
+    struct Input {
+        let sessionId: UUID
+        let requestId: UUID
+        let canvasViewModel: CanvasViewModel
+        let prompt: String?
+        let stylePreset: String
+        let advancedParameters: AdvancedParameters?
+        let isSeedLocked: Bool
+    }
+
+    struct Output {
+        let image: UIImage
+        let seed: Int?
+    }
+
+    private let apiClient: APIClient
+
+    init(apiClient: APIClient) {
+        self.apiClient = apiClient
+    }
+
+    /// Runs the full generation pipeline: snapshot → JPEG → API → image download.
+    ///
+    /// Reports progress via `onPhase`. Returns the generated image on success.
+    /// Throws on any failure. Respects Task cancellation at each phase boundary.
+    /// Returns `nil` if the canvas is empty (no generation needed).
+    func run(
+        input: Input,
+        onPhase: @escaping (GenerationPhase, [GenerationPhase: TimeInterval]) -> Void
+    ) async throws -> Output? {
+        var durations: [GenerationPhase: TimeInterval] = [:]
+        var phaseStart = Date()
+
+        // Phase: preparing (snapshot + JPEG encoding)
+        onPhase(.preparing, durations)
+
+        guard let snapshot = input.canvasViewModel.captureSnapshot(),
+              !snapshot.isEmpty else {
+            return nil
+        }
+
+        guard let jpegData = snapshot.image.jpegData(compressionQuality: 0.85) else {
+            throw PipelineError.jpegEncodingFailed
+        }
+        print("[Generate] JPEG: \(jpegData.count) bytes, image: \(snapshot.image.size)")
+
+        try Task.checkCancellation()
+
+        // Phase: uploading (network round-trip)
+        durations[.preparing] = Date().timeIntervalSince(phaseStart)
+        phaseStart = Date()
+        onPhase(.uploading, durations)
+
+        let request = GenerateRequest(
+            sessionId: input.sessionId,
+            requestId: input.requestId,
+            mode: .preview,
+            prompt: input.prompt,
+            stylePreset: input.stylePreset,
+            sketchImageBase64: jpegData.base64EncodedString(),
+            advancedParameters: input.advancedParameters
+        )
+
+        let response = try await apiClient.generate(request)
+        print("[Generate] Response: status=\(response.status), imageURL=\(response.imageURL?.absoluteString ?? "nil")")
+
+        try Task.checkCancellation()
+
+        guard response.status == .completed, let imageURL = response.imageURL else {
+            throw PipelineError.generationFailed(
+                status: "\(response.status)",
+                imageURL: response.imageURL?.absoluteString
+            )
+        }
+
+        let seed: Int? = input.isSeedLocked ? response.seed : nil
+
+        // Phase: downloading
+        durations[.uploading] = Date().timeIntervalSince(phaseStart)
+        phaseStart = Date()
+        onPhase(.downloading, durations)
+
+        let (data, _) = try await URLSession.shared.data(from: imageURL)
+        guard let image = UIImage(data: data) else {
+            throw PipelineError.imageDecodeFailed(
+                byteCount: data.count,
+                url: imageURL.lastPathComponent
+            )
+        }
+
+        try Task.checkCancellation()
+
+        return Output(image: image, seed: seed)
+    }
+}
+
+// MARK: - Pipeline Errors
+
+enum PipelineError: Error {
+    case jpegEncodingFailed
+    case generationFailed(status: String, imageURL: String?)
+    case imageDecodeFailed(byteCount: Int, url: String)
+
+    var userMessage: String {
+        switch self {
+        case .jpegEncodingFailed:
+            return "Failed to process sketch"
+        case .generationFailed(let status, let imageURL):
+            return "Generation failed — status: \(status), imageURL: \(imageURL ?? "nil")"
+        case .imageDecodeFailed(let byteCount, let url):
+            return "Image decode failed — \(byteCount) bytes from \(url)"
+        }
+    }
+}

--- a/ios/Kiki/App/GenerationPipeline.swift
+++ b/ios/Kiki/App/GenerationPipeline.swift
@@ -18,7 +18,7 @@ final class GenerationPipeline {
 
     struct Output {
         let image: UIImage
-        let seed: Int?
+        let seed: UInt64?
     }
 
     private let apiClient: APIClient
@@ -81,7 +81,7 @@ final class GenerationPipeline {
             )
         }
 
-        let seed: Int? = input.isSeedLocked ? response.seed : nil
+        let seed: UInt64? = input.isSeedLocked ? response.seed : nil
 
         // Phase: downloading
         durations[.uploading] = Date().timeIntervalSince(phaseStart)

--- a/ios/Kiki/App/GenerationTriggerMode.swift
+++ b/ios/Kiki/App/GenerationTriggerMode.swift
@@ -1,0 +1,4 @@
+enum GenerationTriggerMode: String, CaseIterable {
+    case auto
+    case manual
+}

--- a/ios/Kiki/Views/ContentView.swift
+++ b/ios/Kiki/Views/ContentView.swift
@@ -52,6 +52,13 @@ struct ContentView: View {
                             : Color.accentColor,
                         in: Circle()
                     )
+                    .overlay(alignment: .topTrailing) {
+                        if coordinator.hasUnsavedChanges && !coordinator.isGenerating {
+                            Circle()
+                                .fill(.orange)
+                                .frame(width: 8, height: 8)
+                        }
+                    }
             }
             .disabled(coordinator.canvasViewModel.isEmpty || coordinator.isGenerating)
         }

--- a/ios/Kiki/Views/FloatingToolbar.swift
+++ b/ios/Kiki/Views/FloatingToolbar.swift
@@ -61,6 +61,18 @@ struct FloatingToolbar: View {
                 .frame(height: 24)
 
             Button {
+                coordinator.triggerMode = (coordinator.triggerMode == .auto) ? .manual : .auto
+            } label: {
+                Image(systemName: coordinator.triggerMode == .auto ? "bolt.fill" : "hand.tap.fill")
+                    .font(.system(size: 18, weight: .medium))
+                    .foregroundStyle(coordinator.triggerMode == .auto ? Color.accentColor : .primary)
+                    .frame(width: 36, height: 36)
+            }
+
+            Divider()
+                .frame(height: 24)
+
+            Button {
                 showAdvancedParameters = true
             } label: {
                 Image(systemName: coordinator.advancedParameters.isDefault

--- a/ios/Packages/ResultModule/Sources/ResultModule/ResultView.swift
+++ b/ios/Packages/ResultModule/Sources/ResultModule/ResultView.swift
@@ -89,8 +89,16 @@ public struct ResultView: View {
                 emptyView
             }
         }
-        .onAppear {
-            showToastMessage(message)
+        .overlay {
+            // Invisible view with .id(message) forces .onAppear to re-fire when
+            // the error message changes within the same structural view position.
+            // Without this, consecutive errors (e.g. two fast failures during the
+            // synchronous preparation phase) would swallow the second toast.
+            Color.clear
+                .id(message)
+                .onAppear {
+                    showToastMessage(message)
+                }
         }
     }
 


### PR DESCRIPTION
## Summary

- **Refactor:** Extract `GenerationPipeline` from `AppCoordinator`, separating snapshot → JPEG → API → download into a reusable pipeline with phase-based progress reporting
- **Feature:** Add manual/auto generation trigger mode toggle (persisted to UserDefaults) with debounced auto-generation and an unsaved-changes indicator (orange dot)
- **Bug fixes:**
  - Fix `defer` clobber: `isGenerating` was unconditionally cleared by `defer` even when a new task owned it, causing the generate button to re-enable mid-flight
  - Fix cancellation: `CancellationError` catch now returns immediately instead of falling through to the retrigger path
  - Fix empty canvas: `generate()` restores `resultState` to previous image (or `.empty`) instead of leaving it stuck in `.generating`
  - Fix `hasUnsavedChanges` stuck true after `clear()` — canvas observation now skips empty-canvas events
  - Fix consecutive error toasts swallowed — `.onAppear` replaced with `.id(message)` overlay to re-fire on each new error
  - Fix seed type: pipeline `Output.seed` changed from `Int` to `UInt64` to match `AdvancedParameters.seed`

## Test plan

- [ ] Draw strokes → verify auto-generation fires after 1.5s debounce
- [ ] Toggle to manual mode → verify generation only fires on button tap
- [ ] Toggle back to auto → verify debounce resumes
- [ ] Clear canvas → verify no orange dirty dot appears
- [ ] Erase last stroke → verify no dirty dot
- [ ] Draw while generating → verify dirty dot appears, retrigger fires on completion
- [ ] Trigger two rapid failures → verify both error toasts show
- [ ] Lock seed → generate → verify same seed reused on next generation
- [ ] Kill backend → generate → verify error toast with previous image preserved
