### PR TITLE
feat(deploy): warm up ComfyUI models on pod boot

### DIFF
--- a/documents/references/provider-config.md
+++ b/documents/references/provider-config.md
@@ -5,7 +5,7 @@
 ComfyUI on RunPod H100 80GB SXM running Qwen-Image 20B (FP8) + InstantX ControlNet Union.
 
 - ~6-8s per generation (including network round-trip)
-- ~30-60s first generation after cold start (model loading)
+- ~30-60s first generation after cold start (model loading) — mitigated by automatic warmup in `setup-pod.sh`
 - 24GB+ VRAM required (FP8 model uses ~21GB)
 
 Model filenames and pipeline details are in `comfyui-workflow-api.json` (source of truth).
@@ -31,7 +31,7 @@ The action automatically:
 1. Tries existing network volumes for GPU availability
 2. If none available, probes other datacenters and creates a new volume (capped at 10)
 3. Creates a pod with GPU fallback (H100 SXM → H100 PCIe → A100 80GB)
-4. SSHs in and runs `scripts/setup-pod.sh` (symlinks models, installs deps, restarts ComfyUI)
+4. SSHs in and runs `scripts/setup-pod.sh` (symlinks models, installs deps, restarts ComfyUI, warms up models)
 5. On fresh volumes, downloads all models (~30GB, 5-10 min one-time)
 6. Updates Railway `COMFYUI_URL` via API
 7. Shows pod ID, URL, and datacenter in the Summary tab

--- a/scripts/setup-pod.sh
+++ b/scripts/setup-pod.sh
@@ -135,18 +135,127 @@ nohup "$COMFYUI_PYTHON" main.py --listen 0.0.0.0 --port 8188 > /workspace/runpod
 
 echo ""
 echo "==> Waiting for ComfyUI to start..."
+COMFYUI_READY=false
 for i in $(seq 1 30); do
   if curl -s -o /dev/null -w "" http://localhost:8188/system_stats 2>/dev/null; then
     echo "ComfyUI is running on port 8188!"
     echo ""
     curl -s http://localhost:8188/system_stats | python3 -m json.tool 2>/dev/null || true
-    echo ""
-    echo "Setup complete!"
-    exit 0
+    COMFYUI_READY=true
+    break
   fi
   sleep 2
 done
 
-echo "ERROR: ComfyUI did not start within 60s. Last log lines:"
-tail -20 /workspace/runpod-slim/comfyui.log 2>/dev/null || true
-exit 1
+if [ "$COMFYUI_READY" != "true" ]; then
+  echo "ERROR: ComfyUI did not start within 60s. Last log lines:"
+  tail -20 /workspace/runpod-slim/comfyui.log 2>/dev/null || true
+  exit 1
+fi
+
+# ── Step 6: Warm up models (load into VRAM) ──
+
+warmup_models() {
+  local WARMUP_START
+  WARMUP_START=$(date +%s)
+
+  if [ ! -f /tmp/comfyui-workflow-api.json ]; then
+    echo "  Skipping warmup: workflow template not found at /tmp/comfyui-workflow-api.json"
+    return 1
+  fi
+
+  # Create a small dummy image
+  python3 -c "
+from PIL import Image
+img = Image.new('RGB', (256, 256), (128, 128, 128))
+img.save('/tmp/warmup_input.png')
+"
+
+  # Upload dummy image to ComfyUI
+  local UPLOAD_RESP
+  UPLOAD_RESP=$(curl -s -X POST http://localhost:8188/upload/image \
+    -F "image=@/tmp/warmup_input.png" \
+    -F "overwrite=true")
+  local WARMUP_FILENAME
+  WARMUP_FILENAME=$(echo "$UPLOAD_RESP" | python3 -c "import sys,json; print(json.load(sys.stdin)['name'])")
+
+  if [ -z "$WARMUP_FILENAME" ]; then
+    echo "  Failed to upload warmup image"
+    return 1
+  fi
+  echo "  Uploaded warmup image: $WARMUP_FILENAME"
+
+  # Build warmup workflow: use template but with dummy image, minimal prompt, 1 step
+  python3 -c "
+import json
+with open('/tmp/comfyui-workflow-api.json') as f:
+    wf = json.load(f)
+wf['71']['inputs']['image'] = '${WARMUP_FILENAME}'
+wf['111:6']['inputs']['text'] = 'warmup test'
+wf['111:3']['inputs']['steps'] = 1
+wf['111:3']['inputs']['seed'] = 1
+print(json.dumps({'prompt': wf, 'client_id': 'warmup'}))
+" > /tmp/warmup-payload.json
+
+  # Submit warmup workflow
+  local PROMPT_RESP
+  PROMPT_RESP=$(curl -s -X POST http://localhost:8188/prompt \
+    -H "Content-Type: application/json" \
+    -d @/tmp/warmup-payload.json)
+  local PROMPT_ID
+  PROMPT_ID=$(echo "$PROMPT_RESP" | python3 -c "import sys,json; print(json.load(sys.stdin).get('prompt_id',''))")
+
+  if [ -z "$PROMPT_ID" ]; then
+    echo "  Failed to submit warmup workflow"
+    echo "  Response: $PROMPT_RESP"
+    return 1
+  fi
+  echo "  Submitted warmup workflow: $PROMPT_ID"
+
+  # Poll for completion
+  local WARMUP_TIMEOUT=120
+  local WARMUP_POLL=3
+  local WARMUP_ELAPSED=0
+
+  while [ "$WARMUP_ELAPSED" -lt "$WARMUP_TIMEOUT" ]; do
+    local HISTORY
+    HISTORY=$(curl -s "http://localhost:8188/history/${PROMPT_ID}" 2>/dev/null || echo "{}")
+    local STATUS
+    STATUS=$(echo "$HISTORY" | python3 -c "
+import sys, json
+h = json.load(sys.stdin)
+entry = h.get('${PROMPT_ID}', {})
+status = entry.get('status', {})
+if status.get('status_str') == 'error':
+    print('error')
+elif entry.get('outputs', {}).get('60', {}).get('images'):
+    print('done')
+else:
+    print('pending')
+" 2>/dev/null || echo "pending")
+
+    if [ "$STATUS" = "done" ]; then
+      local WARMUP_END
+      WARMUP_END=$(date +%s)
+      echo "  Models loaded and warm! (${WARMUP_ELAPSED}s, total warmup: $((WARMUP_END - WARMUP_START))s)"
+      return 0
+    elif [ "$STATUS" = "error" ]; then
+      echo "  Warmup workflow failed on ComfyUI server"
+      return 1
+    fi
+
+    sleep "$WARMUP_POLL"
+    WARMUP_ELAPSED=$((WARMUP_ELAPSED + WARMUP_POLL))
+  done
+
+  echo "  Warmup timed out after ${WARMUP_TIMEOUT}s"
+  return 1
+}
+
+echo ""
+echo "==> Warming up models (loading into VRAM)..."
+warmup_models || echo "WARNING: Model warmup failed (non-fatal). First request will load models on demand."
+
+echo ""
+echo "Setup complete!"
+exit 0


### PR DESCRIPTION
## Summary
- Adds a model warmup step (Step 6) to `setup-pod.sh` that runs a minimal 1-step generation after ComfyUI starts, forcing all models into VRAM
- Eliminates the 30-60s cold-start penalty on the first real user request after pod deploy
- Warmup is non-fatal — if it fails, the pod still works (first request just takes longer)

## Test plan
- [x] Bash syntax check passed (`bash -n`)
- [x] Tested warmup function on live RunPod pod via SSH — completed in 5s
- [ ] Full end-to-end: run Deploy RunPod GitHub Action and verify first app request is fast (~6-8s)

🤖 Generated with [Claude Code](https://claude.com/claude-code)