### PR TITLE
feat: animate the last still with LTXV 2B while the user is idle

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,10 @@ backend/.env
 # FLUX test-client debug output
 flux-klein-server/output.jpg
 
+# Python
+__pycache__/
+*.pyc
+
 # IDE
 .idea/
 .vscode/

--- a/backend/package.json
+++ b/backend/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "main": "dist/index.js",
   "scripts": {
-    "copy-assets": "mkdir -p runtime-assets/flux-klein-server && if [ -f ../flux-klein-server/server.py ]; then cp ../flux-klein-server/server.py ../flux-klein-server/pipeline.py ../flux-klein-server/config.py ../flux-klein-server/requirements.txt runtime-assets/flux-klein-server/ && cp ../scripts/setup-flux-klein.sh runtime-assets/setup-flux-klein.sh; else echo 'Source assets not reachable (Railway build); using committed runtime-assets/'; fi",
+    "copy-assets": "mkdir -p runtime-assets/flux-klein-server && if [ -f ../flux-klein-server/server.py ]; then cp ../flux-klein-server/server.py ../flux-klein-server/pipeline.py ../flux-klein-server/video_pipeline.py ../flux-klein-server/config.py ../flux-klein-server/requirements.txt runtime-assets/flux-klein-server/ && cp ../scripts/setup-flux-klein.sh runtime-assets/setup-flux-klein.sh; else echo 'Source assets not reachable (Railway build); using committed runtime-assets/'; fi",
     "predev": "npm run copy-assets",
     "prebuild": "npm run copy-assets",
     "dev": "tsx watch src/index.ts",

--- a/backend/runtime-assets/flux-klein-server/config.py
+++ b/backend/runtime-assets/flux-klein-server/config.py
@@ -30,3 +30,18 @@ DTYPE = os.getenv("FLUX_DTYPE", "bfloat16")  # "bfloat16" or "float16"
 USE_NVFP4 = os.getenv("FLUX_USE_NVFP4", "1") == "1"
 NVFP4_REPO = os.getenv("FLUX_NVFP4_REPO", "black-forest-labs/FLUX.2-klein-4b-nvfp4")
 NVFP4_FILENAME = os.getenv("FLUX_NVFP4_FILENAME", "flux-2-klein-4b-nvfp4.safetensors")
+
+# ── LTXV 2B distilled (image-to-video) ────────────────────────────────────
+# Runs whenever the img2img input buffer is empty and we have a last-generated
+# still to animate. Resolution and frame count are set for speed, not quality:
+# the SLA is <5s from "user stopped drawing" to first playback.
+ENABLE_VIDEO = os.getenv("KIKI_ENABLE_VIDEO", "1") == "1"
+LTXV_MODEL_ID = os.getenv("LTXV_MODEL", "Lightricks/LTX-Video-2B-v0.9.1-distilled")
+LTXV_WIDTH = int(os.getenv("LTXV_WIDTH", "512"))
+LTXV_HEIGHT = int(os.getenv("LTXV_HEIGHT", "512"))
+LTXV_NUM_FRAMES = int(os.getenv("LTXV_NUM_FRAMES", "25"))   # ~1s at 24fps
+LTXV_STEPS = int(os.getenv("LTXV_STEPS", "8"))              # distilled = fewer steps
+LTXV_GUIDANCE = float(os.getenv("LTXV_GUIDANCE", "1.0"))
+LTXV_FPS = int(os.getenv("LTXV_FPS", "24"))
+LTXV_DTYPE = os.getenv("LTXV_DTYPE", "bfloat16")
+LTXV_OUTPUT_CRF = int(os.getenv("LTXV_CRF", "28"))           # MP4 quality knob

--- a/backend/runtime-assets/flux-klein-server/config.py
+++ b/backend/runtime-assets/flux-klein-server/config.py
@@ -31,16 +31,27 @@ USE_NVFP4 = os.getenv("FLUX_USE_NVFP4", "1") == "1"
 NVFP4_REPO = os.getenv("FLUX_NVFP4_REPO", "black-forest-labs/FLUX.2-klein-4b-nvfp4")
 NVFP4_FILENAME = os.getenv("FLUX_NVFP4_FILENAME", "flux-2-klein-4b-nvfp4.safetensors")
 
-# ── LTXV 2B distilled (image-to-video) ────────────────────────────────────
+# ── LTXV 2B 0.9.8 distilled (image-to-video) ──────────────────────────────
 # Runs whenever the img2img input buffer is empty and we have a last-generated
 # still to animate. Resolution and frame count are set for speed, not quality:
 # the SLA is <5s from "user stopped drawing" to first playback.
+#
+# The 2B transformer is loaded from a single-file checkpoint in the main
+# Lightricks/LTX-Video repo; VAE, text encoder, and scheduler come from the
+# Lightricks/LTX-Video-0.9.5 repo (same 2B architecture). Weights are stored
+# in FP8 (float8_e4m3fn) via enable_layerwise_casting for lower VRAM + faster
+# inference on Blackwell tensor cores; compute stays in BF16.
 ENABLE_VIDEO = os.getenv("KIKI_ENABLE_VIDEO", "1") == "1"
-LTXV_MODEL_ID = os.getenv("LTXV_MODEL", "Lightricks/LTX-Video-2B-v0.9.1-distilled")
+# Repo that holds VAE, text encoder, scheduler (2B architecture).
+LTXV_BASE_REPO = os.getenv("LTXV_BASE_REPO", "Lightricks/LTX-Video-0.9.5")
+# Single-file transformer checkpoint from the main Lightricks/LTX-Video repo.
+LTXV_TRANSFORMER_REPO = os.getenv("LTXV_TRANSFORMER_REPO", "Lightricks/LTX-Video")
+LTXV_TRANSFORMER_FILE = os.getenv("LTXV_TRANSFORMER_FILE", "ltxv-2b-0.9.8-distilled-fp8.safetensors")
 LTXV_WIDTH = int(os.getenv("LTXV_WIDTH", "512"))
 LTXV_HEIGHT = int(os.getenv("LTXV_HEIGHT", "512"))
 LTXV_NUM_FRAMES = int(os.getenv("LTXV_NUM_FRAMES", "25"))   # ~1s at 24fps
-LTXV_STEPS = int(os.getenv("LTXV_STEPS", "8"))              # distilled = fewer steps
+# Distilled 8-step schedule (normalized timesteps × 1000).
+LTXV_TIMESTEPS = [1000, 993, 987, 981, 975, 909, 725]
 LTXV_GUIDANCE = float(os.getenv("LTXV_GUIDANCE", "1.0"))
 LTXV_FPS = int(os.getenv("LTXV_FPS", "24"))
 LTXV_DTYPE = os.getenv("LTXV_DTYPE", "bfloat16")

--- a/backend/runtime-assets/flux-klein-server/pipeline.py
+++ b/backend/runtime-assets/flux-klein-server/pipeline.py
@@ -22,14 +22,16 @@ class FluxKleinPipeline:
     distillation trajectory doesn't tolerate partial-denoise starts.
     """
 
-    def __init__(self):
+    def __init__(self, gpu_lock: threading.Lock | None = None):
         self.pipe = None
         self._ready = False
         self._dtype = getattr(torch, config.DTYPE)
         self._quantization = "bf16"  # overwritten to "nvfp4" if that path succeeds
         # Serialize pipeline calls — PyTorch is not thread-safe and
-        # asyncio.to_thread could overlap frames.
-        self._lock = threading.Lock()
+        # asyncio.to_thread could overlap frames. If a shared lock is passed in,
+        # use it so the sibling LTXV video pipeline can't run on the same GPU
+        # at the same time.
+        self._lock = gpu_lock if gpu_lock is not None else threading.Lock()
 
     @property
     def ready(self) -> bool:

--- a/backend/runtime-assets/flux-klein-server/requirements.txt
+++ b/backend/runtime-assets/flux-klein-server/requirements.txt
@@ -21,3 +21,6 @@ fastapi>=0.108.0
 uvicorn[standard]>=0.25.0
 websockets>=12.0
 Pillow>=10.0.0
+
+# Video generation (LTXV 2B distilled image-to-video)
+numpy>=1.26.0

--- a/backend/runtime-assets/flux-klein-server/server.py
+++ b/backend/runtime-assets/flux-klein-server/server.py
@@ -91,9 +91,17 @@ async def websocket_stream(ws: WebSocket):
     client_id = id(ws)
     logger.info("Client %d connected", client_id)
 
-    # Send initial status
+    # Send initial status. Include video_ready so the client knows whether
+    # LTXV animation is available for this session.
+    def _ready_status() -> dict:
+        return {
+            "type": "status",
+            "status": "ready",
+            "video_ready": video_pipeline.ready,
+        }
+
     if pipeline.ready:
-        await ws.send_text(json.dumps({"type": "status", "status": "ready"}))
+        await ws.send_text(json.dumps(_ready_status()))
     else:
         await ws.send_text(json.dumps({
             "type": "status",
@@ -102,7 +110,7 @@ async def websocket_stream(ws: WebSocket):
         }))
         while not pipeline.ready:
             await asyncio.sleep(0.5)
-        await ws.send_text(json.dumps({"type": "status", "status": "ready"}))
+        await ws.send_text(json.dumps(_ready_status()))
 
     # Per-connection state. Default seed is random-per-session (not per-frame)
     # so output is stable when the sketch doesn't change. Client can override.
@@ -281,7 +289,7 @@ async def websocket_stream(ws: WebSocket):
 
         # Stream decoded frames one at a time so the client can start playback
         # before the MP4 arrives. If cancelled between frames, bail out.
-        for i, frame in enumerate(frames):
+        for frame in frames:
             if done or video_cancel_event.is_set():
                 if not done:
                     try:

--- a/backend/runtime-assets/flux-klein-server/server.py
+++ b/backend/runtime-assets/flux-klein-server/server.py
@@ -7,19 +7,30 @@ Protocol:
 
   Server -> Client:
     - Text frame (JSON): { "type": "status", "status": "ready" | "warmup" | "error", "message": "..." }
-    - Binary frame: Generated JPEG bytes
+    - Binary frame: Generated JPEG bytes (img2img result)
+    - Text frame (JSON): { "type": "video_frame", "data": "<base64 JPEG>" } — one
+      per decoded LTXV animation frame, sent while the user is idle
+    - Text frame (JSON): { "type": "video_complete", "data": "<base64 MP4>" }
+    - Text frame (JSON): { "type": "video_cancelled" }
 
 Frame dropping:
   The client may send frames faster than the server can generate (~1 FPS).
   Only the latest frame is kept; older frames are dropped. This prevents
   frame queue buildup and keeps the output responsive to the current sketch.
+
+Video generation:
+  When the input buffer is empty and we have a last-generated still,
+  `video_loop` kicks off LTXV animation on the GPU. Arrival of a new
+  input frame cancels the in-flight video generation.
 """
 
 import asyncio
+import base64
 import io
 import json
 import logging
 import random
+import threading
 import time
 from contextlib import asynccontextmanager
 
@@ -29,6 +40,12 @@ from PIL import Image
 
 import config
 from pipeline import FluxKleinPipeline
+from video_pipeline import (
+    LtxvVideoPipeline,
+    VideoCancelled,
+    encode_mp4,
+    frames_to_jpeg,
+)
 
 logging.basicConfig(
     level=logging.INFO,
@@ -36,14 +53,21 @@ logging.basicConfig(
 )
 logger = logging.getLogger(__name__)
 
-pipeline = FluxKleinPipeline()
+# Shared serialization point across FLUX and LTXV — PyTorch isn't thread-safe
+# and both pipelines would otherwise interleave CUDA kernels on the same stream.
+gpu_lock = threading.Lock()
+
+pipeline = FluxKleinPipeline(gpu_lock)
+video_pipeline = LtxvVideoPipeline(gpu_lock)
 
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
-    """Load the model on startup."""
+    """Load the model(s) on startup."""
     logger.info("Starting FLUX.2-klein server...")
     pipeline.load()
+    # LTXV is optional — if it fails to load, the server still serves img2img.
+    video_pipeline.load()
     yield
     logger.info("Shutting down.")
 
@@ -54,6 +78,7 @@ app = FastAPI(lifespan=lifespan)
 @app.get("/health")
 async def health():
     info = pipeline.get_info()
+    info.update(video_pipeline.get_info())
     return {
         "status": "ok" if pipeline.ready else "loading",
         **info,
@@ -98,6 +123,17 @@ async def websocket_stream(ws: WebSocket):
     session_start = time.time()
     done = False
 
+    # ── Video-generation state (LTXV) ────────────────────────────────────
+    # The most recent generated still, used as the first-frame keyframe for
+    # video generation. Reset whenever a new img2img result is produced.
+    last_generated: Image.Image | None = None
+    # Guards against re-generating a video for the same still more than once.
+    video_done_for_last = False
+    # Set to abort an in-flight LTXV generation when a new sketch arrives.
+    video_cancel_event = threading.Event()
+    video_task: asyncio.Task | None = None
+    videos_generated = 0
+
     async def receive_loop():
         """Read messages from the client. Keep only the latest binary frame."""
         nonlocal latest_frame, frames_received, frames_dropped, done, current_config
@@ -139,19 +175,24 @@ async def websocket_stream(ws: WebSocket):
                         frames_dropped += 1
                     latest_frame = message["bytes"]
                     frames_received += 1
+                    # User is drawing again — abort any running video generation.
+                    video_cancel_event.set()
                     frame_event.set()
 
         except WebSocketDisconnect:
             done = True
+            video_cancel_event.set()
             frame_event.set()
         except Exception as e:
             logger.error("Client %d receive error: %s", client_id, e)
             done = True
+            video_cancel_event.set()
             frame_event.set()
 
     async def process_loop():
         """Process the latest frame whenever one is available."""
         nonlocal latest_frame, frames_processed, done
+        nonlocal last_generated, video_done_for_last
 
         while not done:
             await frame_event.wait()
@@ -168,10 +209,18 @@ async def websocket_stream(ws: WebSocket):
 
             try:
                 cfg = dict(current_config)
-                result_jpeg = await asyncio.to_thread(_process_frame, jpeg_data, cfg)
+                result_jpeg, result_image = await asyncio.to_thread(
+                    _process_frame, jpeg_data, cfg
+                )
                 if not done:
                     await ws.send_bytes(result_jpeg)
                     frames_processed += 1
+                    # Stash the PIL result as the keyframe for any future video
+                    # generation. Reset the once-per-still guard + cancel flag
+                    # so the video loop can pick it up on the next idle window.
+                    last_generated = result_image
+                    video_done_for_last = False
+                    video_cancel_event.clear()
             except Exception as e:
                 logger.error("Frame processing error: %s", e, exc_info=True)
                 if not done:
@@ -184,24 +233,137 @@ async def websocket_stream(ws: WebSocket):
                     except Exception:
                         pass
 
-    # Run both loops concurrently
+    async def run_video_generation():
+        """Generate an LTXV animation for the current `last_generated` still
+        and stream frames + MP4 back to the client. Any new sketch arriving
+        during generation aborts via `video_cancel_event`."""
+        nonlocal videos_generated, video_done_for_last
+
+        if last_generated is None:
+            return
+        keyframe = last_generated
+        prompt = str(current_config.get("prompt") or "")
+        seed = current_config.get("seed")
+
+        logger.info(
+            "Client %d: starting LTXV animation (prompt='%s', %d frames, %dx%d)",
+            client_id, prompt[:50], config.LTXV_NUM_FRAMES,
+            config.LTXV_WIDTH, config.LTXV_HEIGHT,
+        )
+        t0 = time.time()
+
+        try:
+            frames = await asyncio.to_thread(
+                video_pipeline.generate,
+                keyframe, prompt, video_cancel_event, seed,
+            )
+        except VideoCancelled:
+            logger.info("Client %d: LTXV cancelled by user", client_id)
+            if not done:
+                try:
+                    await ws.send_text(json.dumps({"type": "video_cancelled"}))
+                except Exception:
+                    pass
+            return
+        except Exception as e:  # noqa: BLE001
+            logger.error("Client %d: LTXV error: %s", client_id, e, exc_info=True)
+            return
+
+        if done or video_cancel_event.is_set():
+            return
+
+        # Stream decoded frames one at a time so the client can start playback
+        # before the MP4 arrives. If cancelled between frames, bail out.
+        for i, frame in enumerate(frames):
+            if done or video_cancel_event.is_set():
+                if not done:
+                    try:
+                        await ws.send_text(json.dumps({"type": "video_cancelled"}))
+                    except Exception:
+                        pass
+                return
+            try:
+                jpeg = frames_to_jpeg(frame, quality=config.OUTPUT_JPEG_QUALITY)
+                await ws.send_text(json.dumps({
+                    "type": "video_frame",
+                    "data": base64.b64encode(jpeg).decode("ascii"),
+                }))
+            except Exception as e:  # noqa: BLE001
+                logger.warning("Client %d: video_frame send failed: %s", client_id, e)
+                return
+
+        # Encode the full MP4 for smooth looping on the client.
+        try:
+            mp4 = await asyncio.to_thread(
+                encode_mp4, frames, config.LTXV_FPS, config.LTXV_OUTPUT_CRF,
+            )
+            if done:
+                return
+            await ws.send_text(json.dumps({
+                "type": "video_complete",
+                "data": base64.b64encode(mp4).decode("ascii"),
+            }))
+            video_done_for_last = True
+            videos_generated += 1
+            logger.info(
+                "Client %d: LTXV done in %.1fs (%d frames, %d bytes MP4)",
+                client_id, time.time() - t0, len(frames), len(mp4),
+            )
+        except Exception as e:  # noqa: BLE001
+            logger.error("Client %d: MP4 encode failed: %s", client_id, e, exc_info=True)
+
+    async def video_loop():
+        """Poll for idle windows (no input frame, no in-flight generation) and
+        kick off LTXV animation. Runs concurrently with receive/process loops."""
+        nonlocal video_task
+
+        if not video_pipeline.ready:
+            return
+        # Small wait so the initial warmup img2img frame has a chance to land.
+        await asyncio.sleep(0.5)
+        while not done:
+            await asyncio.sleep(0.1)
+            if done:
+                break
+            if latest_frame is not None:
+                continue
+            if last_generated is None:
+                continue
+            if video_done_for_last:
+                continue
+            if video_task is not None and not video_task.done():
+                continue
+            # Clear the abort flag just before we launch so stale signals from
+            # the previous generation don't carry over.
+            video_cancel_event.clear()
+            video_task = asyncio.create_task(run_video_generation())
+
+    # Run all loops concurrently
     try:
-        await asyncio.gather(receive_loop(), process_loop())
+        await asyncio.gather(receive_loop(), process_loop(), video_loop())
     except Exception as e:
         logger.error("WebSocket error for client %d: %s", client_id, e, exc_info=True)
     finally:
+        # Make sure any in-flight video generation stops cleanly.
+        video_cancel_event.set()
+        if video_task is not None and not video_task.done():
+            video_task.cancel()
         elapsed = time.time() - session_start
         fps = frames_processed / elapsed if elapsed > 0 else 0
         logger.info(
-            "Client %d disconnected. Received %d, processed %d, dropped %d, %.1f FPS over %.1fs",
-            client_id, frames_received, frames_processed, frames_dropped, fps, elapsed,
+            "Client %d disconnected. Received %d, processed %d, dropped %d, "
+            "videos %d, %.1f FPS over %.1fs",
+            client_id, frames_received, frames_processed, frames_dropped,
+            videos_generated, fps, elapsed,
         )
 
 
-def _process_frame(jpeg_data: bytes, cfg: dict) -> bytes:
+def _process_frame(jpeg_data: bytes, cfg: dict) -> tuple[bytes, Image.Image]:
     """Decode JPEG, run through pipeline, encode result as JPEG.
 
-    Runs in a thread to avoid blocking the event loop.
+    Returns the encoded JPEG bytes plus the PIL result so the caller can
+    reuse it as a keyframe for subsequent LTXV animation. Runs in a thread
+    to avoid blocking the event loop.
     """
     image = Image.open(io.BytesIO(jpeg_data)).convert("RGB")
     image = image.resize((config.DEFAULT_WIDTH, config.DEFAULT_HEIGHT), Image.LANCZOS)
@@ -215,7 +377,7 @@ def _process_frame(jpeg_data: bytes, cfg: dict) -> bytes:
 
     buffer = io.BytesIO()
     output.save(buffer, format="JPEG", quality=config.OUTPUT_JPEG_QUALITY)
-    return buffer.getvalue()
+    return buffer.getvalue(), output
 
 
 if __name__ == "__main__":

--- a/backend/runtime-assets/flux-klein-server/server.py
+++ b/backend/runtime-assets/flux-klein-server/server.py
@@ -216,11 +216,18 @@ async def websocket_stream(ws: WebSocket):
                     await ws.send_bytes(result_jpeg)
                     frames_processed += 1
                     # Stash the PIL result as the keyframe for any future video
-                    # generation. Reset the once-per-still guard + cancel flag
-                    # so the video loop can pick it up on the next idle window.
+                    # generation. Reset the once-per-still guard so the video
+                    # loop can pick this still up on the next idle window.
+                    #
+                    # NOTE: do NOT clear `video_cancel_event` here. The previous
+                    # in-flight video task's per-step callback may not have
+                    # observed the set yet — clearing now would let it complete
+                    # for the *previous* still and incorrectly mark
+                    # `video_done_for_last`. `video_loop` clears the flag itself
+                    # right before launching the next task, after confirming any
+                    # prior task is done.
                     last_generated = result_image
                     video_done_for_last = False
-                    video_cancel_event.clear()
             except Exception as e:
                 logger.error("Frame processing error: %s", e, exc_info=True)
                 if not done:

--- a/backend/runtime-assets/flux-klein-server/video_pipeline.py
+++ b/backend/runtime-assets/flux-klein-server/video_pipeline.py
@@ -1,0 +1,191 @@
+"""LTXV 2B distilled image-to-video pipeline.
+
+Runs alongside the FLUX img2img pipeline on the same GPU. When the user stops
+drawing (input buffer goes idle), the server feeds the last generated still
+into this pipeline as a keyframe and streams back frames + a looping MP4.
+
+Kept deliberately minimal — resolution, frame count, and step count are
+tuned for speed (SLA: <5s time-to-first-playback), not quality.
+"""
+
+import io
+import logging
+import subprocess
+import tempfile
+import threading
+import time
+from pathlib import Path
+
+import torch
+from PIL import Image
+
+import config
+
+logger = logging.getLogger(__name__)
+
+
+class VideoCancelled(Exception):
+    """Raised from the per-step callback to abort a running LTXV generation
+    when the user resumes drawing. Caller should suppress this and treat it
+    as a normal cancellation, not an error."""
+
+
+class LtxvVideoPipeline:
+    """Wraps LTX-Video 2B distilled for image-to-video generation.
+
+    The pipeline is loaded once at pod startup and reused across all client
+    connections. Concurrent access is serialized via `gpu_lock` (passed in
+    by the server so FLUX and LTXV can't run at the same time on the same
+    CUDA stream).
+    """
+
+    def __init__(self, gpu_lock: threading.Lock):
+        self.pipe = None
+        self._ready = False
+        self._dtype = getattr(torch, config.LTXV_DTYPE)
+        self._gpu_lock = gpu_lock
+
+    @property
+    def ready(self) -> bool:
+        return self._ready
+
+    def load(self) -> None:
+        if not config.ENABLE_VIDEO:
+            logger.info("Video generation disabled (KIKI_ENABLE_VIDEO=0); skipping LTXV load")
+            return
+
+        logger.info("Loading LTXV model: %s (dtype=%s)", config.LTXV_MODEL_ID, config.LTXV_DTYPE)
+        t0 = time.time()
+
+        try:
+            from diffusers import LTXImageToVideoPipeline
+
+            self.pipe = LTXImageToVideoPipeline.from_pretrained(
+                config.LTXV_MODEL_ID,
+                torch_dtype=self._dtype,
+            ).to("cuda")
+
+            # A tiny warmup so the first user-facing call doesn't pay the
+            # CUDA graph / kernel compilation cost.
+            logger.info("Warming up LTXV...")
+            t1 = time.time()
+            warmup_image = Image.new("RGB", (config.LTXV_WIDTH, config.LTXV_HEIGHT), "gray")
+            with self._gpu_lock:
+                _ = self.pipe(
+                    image=warmup_image,
+                    prompt="warmup",
+                    num_frames=config.LTXV_NUM_FRAMES,
+                    num_inference_steps=config.LTXV_STEPS,
+                    guidance_scale=config.LTXV_GUIDANCE,
+                    width=config.LTXV_WIDTH,
+                    height=config.LTXV_HEIGHT,
+                    generator=torch.Generator(device="cuda").manual_seed(0),
+                )
+            logger.info("LTXV warmup done (%.1fs)", time.time() - t1)
+            self._ready = True
+            logger.info("LTXV ready. Total init: %.1fs", time.time() - t0)
+        except Exception as e:  # noqa: BLE001 — want fail-soft so FLUX still serves
+            logger.error("LTXV load failed (%s: %s); video generation disabled", type(e).__name__, e)
+            self.pipe = None
+            self._ready = False
+
+    def generate(
+        self,
+        image: Image.Image,
+        prompt: str,
+        cancel_event: threading.Event,
+        seed: int | None = None,
+    ) -> list[Image.Image]:
+        """Generate an image-to-video animation.
+
+        Returns the list of decoded frames (PIL images). If `cancel_event`
+        is set between steps, raises `VideoCancelled` — the caller should
+        catch this and treat it as a normal abort.
+        """
+        if not self._ready or self.pipe is None:
+            raise RuntimeError("LTXV pipeline not ready")
+
+        # LTX expects the keyframe to be resized to the generation resolution.
+        keyframe = image.convert("RGB").resize(
+            (config.LTXV_WIDTH, config.LTXV_HEIGHT), Image.LANCZOS
+        )
+
+        # Per-step cancel check. Runs on the GPU thread between denoising
+        # steps; raising aborts the pipeline call.
+        def step_cancel(pipe, step_index, timestep, callback_kwargs):
+            if cancel_event.is_set():
+                raise VideoCancelled()
+            return callback_kwargs
+
+        generator = (
+            torch.Generator(device="cuda").manual_seed(seed) if seed is not None else None
+        )
+
+        with self._gpu_lock:
+            if cancel_event.is_set():
+                raise VideoCancelled()
+            result = self.pipe(
+                image=keyframe,
+                prompt=prompt or "",
+                num_frames=config.LTXV_NUM_FRAMES,
+                num_inference_steps=config.LTXV_STEPS,
+                guidance_scale=config.LTXV_GUIDANCE,
+                width=config.LTXV_WIDTH,
+                height=config.LTXV_HEIGHT,
+                generator=generator,
+                callback_on_step_end=step_cancel,
+                output_type="pil",
+            )
+
+        # diffusers returns `frames` as a list of lists (batch dim).
+        frames = result.frames[0] if hasattr(result, "frames") else result.videos[0]
+        return list(frames)
+
+    def get_info(self) -> dict:
+        return {
+            "video_enabled": config.ENABLE_VIDEO,
+            "video_ready": self._ready,
+            "video_model": config.LTXV_MODEL_ID if self._ready else None,
+            "video_resolution": f"{config.LTXV_WIDTH}x{config.LTXV_HEIGHT}",
+            "video_num_frames": config.LTXV_NUM_FRAMES,
+        }
+
+
+def frames_to_jpeg(frame: Image.Image, quality: int = 80) -> bytes:
+    buf = io.BytesIO()
+    frame.save(buf, format="JPEG", quality=quality)
+    return buf.getvalue()
+
+
+def encode_mp4(frames: list[Image.Image], fps: int, crf: int) -> bytes:
+    """Encode a list of PIL frames into an H.264 MP4 blob via ffmpeg.
+
+    Writes frames as PNGs to a tempdir and invokes ffmpeg once. ~200–500ms
+    overhead for a short clip — acceptable within the <5s SLA.
+    """
+    if not frames:
+        raise ValueError("encode_mp4: no frames")
+
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp_path = Path(tmp)
+        for i, f in enumerate(frames):
+            f.save(tmp_path / f"frame_{i:05d}.png")
+        out_path = tmp_path / "out.mp4"
+
+        # yuv420p + even dimensions needed for AVPlayer/Safari compatibility.
+        subprocess.run(
+            [
+                "ffmpeg",
+                "-loglevel", "error",
+                "-y",
+                "-framerate", str(fps),
+                "-i", str(tmp_path / "frame_%05d.png"),
+                "-c:v", "libx264",
+                "-pix_fmt", "yuv420p",
+                "-crf", str(crf),
+                "-movflags", "+faststart",
+                str(out_path),
+            ],
+            check=True,
+        )
+        return out_path.read_bytes()

--- a/backend/runtime-assets/flux-klein-server/video_pipeline.py
+++ b/backend/runtime-assets/flux-klein-server/video_pipeline.py
@@ -1,8 +1,13 @@
-"""LTXV 2B distilled image-to-video pipeline.
+"""LTXV 2B 0.9.8 distilled image-to-video pipeline.
 
 Runs alongside the FLUX img2img pipeline on the same GPU. When the user stops
 drawing (input buffer goes idle), the server feeds the last generated still
 into this pipeline as a keyframe and streams back frames + a looping MP4.
+
+Uses LTXConditionPipeline (0.9.5+ API) with the 2B 0.9.8 distilled
+transformer loaded from a single-file checkpoint. Weights are stored in FP8
+(float8_e4m3fn) via enable_layerwise_casting for lower VRAM and faster
+inference on Blackwell tensor cores; compute stays in BF16.
 
 Kept deliberately minimal — resolution, frame count, and step count are
 tuned for speed (SLA: <5s time-to-first-playback), not quality.
@@ -31,7 +36,7 @@ class VideoCancelled(Exception):
 
 
 class LtxvVideoPipeline:
-    """Wraps LTX-Video 2B distilled for image-to-video generation.
+    """Wraps LTX-Video 2B 0.9.8 distilled for image-to-video generation.
 
     The pipeline is loaded once at pod startup and reused across all client
     connections. Concurrent access is serialized via `gpu_lock` (passed in
@@ -54,33 +59,50 @@ class LtxvVideoPipeline:
             logger.info("Video generation disabled (KIKI_ENABLE_VIDEO=0); skipping LTXV load")
             return
 
-        logger.info("Loading LTXV model: %s (dtype=%s)", config.LTXV_MODEL_ID, config.LTXV_DTYPE)
+        logger.info(
+            "Loading LTXV 2B 0.9.8 distilled (base=%s, transformer=%s/%s)",
+            config.LTXV_BASE_REPO, config.LTXV_TRANSFORMER_REPO,
+            config.LTXV_TRANSFORMER_FILE,
+        )
         t0 = time.time()
 
         try:
-            from diffusers import LTXImageToVideoPipeline
+            from diffusers import AutoModel, LTXConditionPipeline
 
-            self.pipe = LTXImageToVideoPipeline.from_pretrained(
-                config.LTXV_MODEL_ID,
+            # Load the 2B transformer from the pre-quantized FP8 checkpoint.
+            # from_single_file upcasts to BF16 on load; we then apply
+            # layerwise_casting to store FP8 / compute BF16 for inference.
+            logger.info("Loading transformer from single file...")
+            transformer = AutoModel.from_single_file(
+                f"https://huggingface.co/{config.LTXV_TRANSFORMER_REPO}/blob/main/{config.LTXV_TRANSFORMER_FILE}",
+                config=config.LTXV_BASE_REPO,
+                subfolder="transformer",
+                torch_dtype=self._dtype,
+            )
+
+            logger.info("Applying FP8 layerwise casting...")
+            transformer.enable_layerwise_casting(
+                storage_dtype=torch.float8_e4m3fn,
+                compute_dtype=torch.bfloat16,
+            )
+
+            # Assemble the full pipeline from the 0.9.5 repo (VAE, text
+            # encoder, scheduler) with our transformer swapped in.
+            logger.info("Assembling pipeline from %s...", config.LTXV_BASE_REPO)
+            self.pipe = LTXConditionPipeline.from_pretrained(
+                config.LTXV_BASE_REPO,
+                transformer=transformer,
                 torch_dtype=self._dtype,
             ).to("cuda")
+            self.pipe.vae.enable_tiling()
 
-            # A tiny warmup so the first user-facing call doesn't pay the
-            # CUDA graph / kernel compilation cost.
+            # Warmup so the first user-facing call doesn't pay CUDA graph /
+            # kernel compilation cost.
             logger.info("Warming up LTXV...")
             t1 = time.time()
             warmup_image = Image.new("RGB", (config.LTXV_WIDTH, config.LTXV_HEIGHT), "gray")
             with self._gpu_lock:
-                _ = self.pipe(
-                    image=warmup_image,
-                    prompt="warmup",
-                    num_frames=config.LTXV_NUM_FRAMES,
-                    num_inference_steps=config.LTXV_STEPS,
-                    guidance_scale=config.LTXV_GUIDANCE,
-                    width=config.LTXV_WIDTH,
-                    height=config.LTXV_HEIGHT,
-                    generator=torch.Generator(device="cuda").manual_seed(0),
-                )
+                self._run_generation(warmup_image, "warmup", None, 0)
             logger.info("LTXV warmup done (%.1fs)", time.time() - t1)
             self._ready = True
             logger.info("LTXV ready. Total init: %.1fs", time.time() - t0)
@@ -88,6 +110,56 @@ class LtxvVideoPipeline:
             logger.error("LTXV load failed (%s: %s); video generation disabled", type(e).__name__, e)
             self.pipe = None
             self._ready = False
+
+    def _run_generation(
+        self,
+        image: Image.Image,
+        prompt: str,
+        cancel_event: threading.Event | None,
+        seed: int | None,
+    ) -> list[Image.Image]:
+        """Inner generation call — assumes gpu_lock is held."""
+        from diffusers.pipelines.ltx.pipeline_ltx_condition import LTXVideoCondition
+        from diffusers.utils import export_to_video, load_video
+
+        # LTXConditionPipeline expects video-codec-compressed conditioning.
+        # Export the single image as a 1-frame video, then load it back.
+        keyframe = image.convert("RGB").resize(
+            (config.LTXV_WIDTH, config.LTXV_HEIGHT), Image.LANCZOS
+        )
+        with tempfile.NamedTemporaryFile(suffix=".mp4", delete=True) as tmp:
+            export_to_video([keyframe], tmp.name, fps=config.LTXV_FPS)
+            video_cond = load_video(tmp.name)
+        condition = LTXVideoCondition(video=video_cond, frame_index=0)
+
+        # Per-step cancel check.
+        def step_cancel(pipe, step_index, timestep, callback_kwargs):
+            if cancel_event is not None and cancel_event.is_set():
+                raise VideoCancelled()
+            return callback_kwargs
+
+        generator = (
+            torch.Generator(device="cuda").manual_seed(seed) if seed is not None else None
+        )
+
+        result = self.pipe(
+            conditions=[condition],
+            prompt=prompt or "",
+            negative_prompt="worst quality, inconsistent motion, blurry, jittery, distorted",
+            width=config.LTXV_WIDTH,
+            height=config.LTXV_HEIGHT,
+            num_frames=config.LTXV_NUM_FRAMES,
+            timesteps=config.LTXV_TIMESTEPS,
+            guidance_scale=config.LTXV_GUIDANCE,
+            decode_timestep=0.05,
+            decode_noise_scale=0.025,
+            generator=generator,
+            callback_on_step_end=step_cancel,
+            output_type="pil",
+        )
+
+        frames = result.frames[0] if hasattr(result, "frames") else result.videos[0]
+        return list(frames)
 
     def generate(
         self,
@@ -105,47 +177,16 @@ class LtxvVideoPipeline:
         if not self._ready or self.pipe is None:
             raise RuntimeError("LTXV pipeline not ready")
 
-        # LTX expects the keyframe to be resized to the generation resolution.
-        keyframe = image.convert("RGB").resize(
-            (config.LTXV_WIDTH, config.LTXV_HEIGHT), Image.LANCZOS
-        )
-
-        # Per-step cancel check. Runs on the GPU thread between denoising
-        # steps; raising aborts the pipeline call.
-        def step_cancel(pipe, step_index, timestep, callback_kwargs):
-            if cancel_event.is_set():
-                raise VideoCancelled()
-            return callback_kwargs
-
-        generator = (
-            torch.Generator(device="cuda").manual_seed(seed) if seed is not None else None
-        )
-
         with self._gpu_lock:
             if cancel_event.is_set():
                 raise VideoCancelled()
-            result = self.pipe(
-                image=keyframe,
-                prompt=prompt or "",
-                num_frames=config.LTXV_NUM_FRAMES,
-                num_inference_steps=config.LTXV_STEPS,
-                guidance_scale=config.LTXV_GUIDANCE,
-                width=config.LTXV_WIDTH,
-                height=config.LTXV_HEIGHT,
-                generator=generator,
-                callback_on_step_end=step_cancel,
-                output_type="pil",
-            )
-
-        # diffusers returns `frames` as a list of lists (batch dim).
-        frames = result.frames[0] if hasattr(result, "frames") else result.videos[0]
-        return list(frames)
+            return self._run_generation(image, prompt, cancel_event, seed)
 
     def get_info(self) -> dict:
         return {
             "video_enabled": config.ENABLE_VIDEO,
             "video_ready": self._ready,
-            "video_model": config.LTXV_MODEL_ID if self._ready else None,
+            "video_model": "ltxv-2b-0.9.8-distilled-fp8" if self._ready else None,
             "video_resolution": f"{config.LTXV_WIDTH}x{config.LTXV_HEIGHT}",
             "video_num_frames": config.LTXV_NUM_FRAMES,
         }

--- a/backend/scripts/populate-volume.ts
+++ b/backend/scripts/populate-volume.ts
@@ -54,6 +54,9 @@ const SSH_KEY_PATH = '/tmp/kiki-populate-key';
 const FLUX_REPO = 'black-forest-labs/FLUX.2-klein-4B';
 const NVFP4_REPO = 'black-forest-labs/FLUX.2-klein-4b-nvfp4';
 const NVFP4_FILENAME = 'flux-2-klein-4b-nvfp4.safetensors';
+// LTXV 2B distilled: used for idle-state video animation of the last generated still.
+// Must match config.LTXV_MODEL_ID in flux-klein-server/config.py.
+const LTXV_REPO = 'Lightricks/LTX-Video-2B-v0.9.1-distilled';
 
 // ─── GraphQL helper ───────────────────────────────────────────────────────
 
@@ -243,6 +246,16 @@ python3 -c "
 from huggingface_hub import hf_hub_download
 p = hf_hub_download('${NVFP4_REPO}', '${NVFP4_FILENAME}')
 print('nvfp4 weights at', p)
+"
+
+echo "=== Downloading ${LTXV_REPO} (LTXV 2B distilled, ~4 GB) ==="
+python3 -c "
+from huggingface_hub import snapshot_download
+p = snapshot_download(
+    '${LTXV_REPO}',
+    allow_patterns=['*.json','*.safetensors','*.txt','tokenizer*/*','text_encoder*/*','transformer/*','vae/*','scheduler/*','model_index.json'],
+)
+print('ltxv weights at', p)
 "
 
 echo "=== Disk after ==="

--- a/backend/scripts/populate-volume.ts
+++ b/backend/scripts/populate-volume.ts
@@ -54,9 +54,13 @@ const SSH_KEY_PATH = '/tmp/kiki-populate-key';
 const FLUX_REPO = 'black-forest-labs/FLUX.2-klein-4B';
 const NVFP4_REPO = 'black-forest-labs/FLUX.2-klein-4b-nvfp4';
 const NVFP4_FILENAME = 'flux-2-klein-4b-nvfp4.safetensors';
-// LTXV 2B distilled: used for idle-state video animation of the last generated still.
-// Must match config.LTXV_MODEL_ID in flux-klein-server/config.py.
-const LTXV_REPO = 'Lightricks/LTX-Video-2B-v0.9.1-distilled';
+// LTXV 2B 0.9.8 distilled: used for idle-state video animation.
+// VAE/text_encoder/scheduler come from the 0.9.5 base repo (same 2B arch).
+// The 0.9.8 distilled transformer is a single-file checkpoint in the main repo.
+// Must match config.LTXV_BASE_REPO / LTXV_TRANSFORMER_* in flux-klein-server/config.py.
+const LTXV_BASE_REPO = 'Lightricks/LTX-Video-0.9.5';
+const LTXV_TRANSFORMER_REPO = 'Lightricks/LTX-Video';
+const LTXV_TRANSFORMER_FILE = 'ltxv-2b-0.9.8-distilled-fp8.safetensors';
 
 // ─── GraphQL helper ───────────────────────────────────────────────────────
 
@@ -248,14 +252,24 @@ p = hf_hub_download('${NVFP4_REPO}', '${NVFP4_FILENAME}')
 print('nvfp4 weights at', p)
 "
 
-echo "=== Downloading ${LTXV_REPO} (LTXV 2B distilled, ~4 GB) ==="
+echo "=== Downloading ${LTXV_BASE_REPO} (VAE/text_encoder/scheduler — skip transformer, ~16 GB) ==="
 python3 -c "
 from huggingface_hub import snapshot_download
+# Download everything except the 0.9.5 transformer weights — we replace
+# those with the 0.9.8 distilled single-file checkpoint below.
 p = snapshot_download(
-    '${LTXV_REPO}',
-    allow_patterns=['*.json','*.safetensors','*.txt','tokenizer*/*','text_encoder*/*','transformer/*','vae/*','scheduler/*','model_index.json'],
+    '${LTXV_BASE_REPO}',
+    allow_patterns=['*.json','*.txt','model_index.json','tokenizer*/*','text_encoder*/*','vae/*','scheduler/*','transformer/config.json'],
+    ignore_patterns=['transformer/*.safetensors'],
 )
-print('ltxv weights at', p)
+print('ltxv base at', p)
+"
+
+echo "=== Downloading ${LTXV_TRANSFORMER_REPO}/${LTXV_TRANSFORMER_FILE} (0.9.8 distilled transformer, ~6 GB) ==="
+python3 -c "
+from huggingface_hub import hf_hub_download
+p = hf_hub_download('${LTXV_TRANSFORMER_REPO}', '${LTXV_TRANSFORMER_FILE}')
+print('ltxv transformer at', p)
 "
 
 echo "=== Disk after ==="

--- a/flux-klein-server/Dockerfile
+++ b/flux-klein-server/Dockerfile
@@ -20,8 +20,9 @@ ENV HF_HUB_DISABLE_TELEMETRY=1
 
 # ─── Layer 1: OS deps ───────────────────────────────────────────────────
 # git is needed to pip-install diffusers from source.
+# ffmpeg is used by the LTXV video pipeline to encode the final looping MP4.
 RUN apt-get update \
- && apt-get install -y --no-install-recommends git \
+ && apt-get install -y --no-install-recommends git ffmpeg \
  && rm -rf /var/lib/apt/lists/*
 
 # ─── Layer 2: Python deps ───────────────────────────────────────────────
@@ -31,7 +32,7 @@ RUN pip install --no-cache-dir -r /tmp/requirements.txt \
 
 # ─── Layer 3: server code ───────────────────────────────────────────────
 WORKDIR /app
-COPY server.py pipeline.py config.py /app/
+COPY server.py pipeline.py video_pipeline.py config.py /app/
 
 # Offline mode — weights are on the network volume; refuse network lookups so
 # a transient DNS issue doesn't trigger a silent re-download.
@@ -40,6 +41,9 @@ ENV HF_HUB_OFFLINE=1
 ENV FLUX_HOST=0.0.0.0
 ENV FLUX_PORT=8766
 ENV FLUX_USE_NVFP4=1
+# LTXV 2B distilled animates the last generated still while the user is idle.
+# Both FLUX.2-klein (~8 GB) and LTXV 2B (~4 GB) stay resident on the 5090.
+ENV KIKI_ENABLE_VIDEO=1
 
 EXPOSE 8766
 

--- a/flux-klein-server/config.py
+++ b/flux-klein-server/config.py
@@ -30,3 +30,18 @@ DTYPE = os.getenv("FLUX_DTYPE", "bfloat16")  # "bfloat16" or "float16"
 USE_NVFP4 = os.getenv("FLUX_USE_NVFP4", "1") == "1"
 NVFP4_REPO = os.getenv("FLUX_NVFP4_REPO", "black-forest-labs/FLUX.2-klein-4b-nvfp4")
 NVFP4_FILENAME = os.getenv("FLUX_NVFP4_FILENAME", "flux-2-klein-4b-nvfp4.safetensors")
+
+# ── LTXV 2B distilled (image-to-video) ────────────────────────────────────
+# Runs whenever the img2img input buffer is empty and we have a last-generated
+# still to animate. Resolution and frame count are set for speed, not quality:
+# the SLA is <5s from "user stopped drawing" to first playback.
+ENABLE_VIDEO = os.getenv("KIKI_ENABLE_VIDEO", "1") == "1"
+LTXV_MODEL_ID = os.getenv("LTXV_MODEL", "Lightricks/LTX-Video-2B-v0.9.1-distilled")
+LTXV_WIDTH = int(os.getenv("LTXV_WIDTH", "512"))
+LTXV_HEIGHT = int(os.getenv("LTXV_HEIGHT", "512"))
+LTXV_NUM_FRAMES = int(os.getenv("LTXV_NUM_FRAMES", "25"))   # ~1s at 24fps
+LTXV_STEPS = int(os.getenv("LTXV_STEPS", "8"))              # distilled = fewer steps
+LTXV_GUIDANCE = float(os.getenv("LTXV_GUIDANCE", "1.0"))
+LTXV_FPS = int(os.getenv("LTXV_FPS", "24"))
+LTXV_DTYPE = os.getenv("LTXV_DTYPE", "bfloat16")
+LTXV_OUTPUT_CRF = int(os.getenv("LTXV_CRF", "28"))           # MP4 quality knob

--- a/flux-klein-server/config.py
+++ b/flux-klein-server/config.py
@@ -31,16 +31,27 @@ USE_NVFP4 = os.getenv("FLUX_USE_NVFP4", "1") == "1"
 NVFP4_REPO = os.getenv("FLUX_NVFP4_REPO", "black-forest-labs/FLUX.2-klein-4b-nvfp4")
 NVFP4_FILENAME = os.getenv("FLUX_NVFP4_FILENAME", "flux-2-klein-4b-nvfp4.safetensors")
 
-# ── LTXV 2B distilled (image-to-video) ────────────────────────────────────
+# ── LTXV 2B 0.9.8 distilled (image-to-video) ──────────────────────────────
 # Runs whenever the img2img input buffer is empty and we have a last-generated
 # still to animate. Resolution and frame count are set for speed, not quality:
 # the SLA is <5s from "user stopped drawing" to first playback.
+#
+# The 2B transformer is loaded from a single-file checkpoint in the main
+# Lightricks/LTX-Video repo; VAE, text encoder, and scheduler come from the
+# Lightricks/LTX-Video-0.9.5 repo (same 2B architecture). Weights are stored
+# in FP8 (float8_e4m3fn) via enable_layerwise_casting for lower VRAM + faster
+# inference on Blackwell tensor cores; compute stays in BF16.
 ENABLE_VIDEO = os.getenv("KIKI_ENABLE_VIDEO", "1") == "1"
-LTXV_MODEL_ID = os.getenv("LTXV_MODEL", "Lightricks/LTX-Video-2B-v0.9.1-distilled")
+# Repo that holds VAE, text encoder, scheduler (2B architecture).
+LTXV_BASE_REPO = os.getenv("LTXV_BASE_REPO", "Lightricks/LTX-Video-0.9.5")
+# Single-file transformer checkpoint from the main Lightricks/LTX-Video repo.
+LTXV_TRANSFORMER_REPO = os.getenv("LTXV_TRANSFORMER_REPO", "Lightricks/LTX-Video")
+LTXV_TRANSFORMER_FILE = os.getenv("LTXV_TRANSFORMER_FILE", "ltxv-2b-0.9.8-distilled-fp8.safetensors")
 LTXV_WIDTH = int(os.getenv("LTXV_WIDTH", "512"))
 LTXV_HEIGHT = int(os.getenv("LTXV_HEIGHT", "512"))
 LTXV_NUM_FRAMES = int(os.getenv("LTXV_NUM_FRAMES", "25"))   # ~1s at 24fps
-LTXV_STEPS = int(os.getenv("LTXV_STEPS", "8"))              # distilled = fewer steps
+# Distilled 8-step schedule (normalized timesteps × 1000).
+LTXV_TIMESTEPS = [1000, 993, 987, 981, 975, 909, 725]
 LTXV_GUIDANCE = float(os.getenv("LTXV_GUIDANCE", "1.0"))
 LTXV_FPS = int(os.getenv("LTXV_FPS", "24"))
 LTXV_DTYPE = os.getenv("LTXV_DTYPE", "bfloat16")

--- a/flux-klein-server/pipeline.py
+++ b/flux-klein-server/pipeline.py
@@ -22,14 +22,16 @@ class FluxKleinPipeline:
     distillation trajectory doesn't tolerate partial-denoise starts.
     """
 
-    def __init__(self):
+    def __init__(self, gpu_lock: threading.Lock | None = None):
         self.pipe = None
         self._ready = False
         self._dtype = getattr(torch, config.DTYPE)
         self._quantization = "bf16"  # overwritten to "nvfp4" if that path succeeds
         # Serialize pipeline calls — PyTorch is not thread-safe and
-        # asyncio.to_thread could overlap frames.
-        self._lock = threading.Lock()
+        # asyncio.to_thread could overlap frames. If a shared lock is passed in,
+        # use it so the sibling LTXV video pipeline can't run on the same GPU
+        # at the same time.
+        self._lock = gpu_lock if gpu_lock is not None else threading.Lock()
 
     @property
     def ready(self) -> bool:

--- a/flux-klein-server/requirements.txt
+++ b/flux-klein-server/requirements.txt
@@ -21,3 +21,9 @@ fastapi>=0.108.0
 uvicorn[standard]>=0.25.0
 websockets>=12.0
 Pillow>=10.0.0
+
+# Video generation (LTXV 2B distilled image-to-video). imageio-ffmpeg bundles
+# an ffmpeg binary as a fallback; we also install system ffmpeg in the
+# Dockerfile so the subprocess-based encode path works without extra config.
+imageio[ffmpeg]>=2.31.0
+numpy>=1.26.0

--- a/flux-klein-server/requirements.txt
+++ b/flux-klein-server/requirements.txt
@@ -22,8 +22,5 @@ uvicorn[standard]>=0.25.0
 websockets>=12.0
 Pillow>=10.0.0
 
-# Video generation (LTXV 2B distilled image-to-video). imageio-ffmpeg bundles
-# an ffmpeg binary as a fallback; we also install system ffmpeg in the
-# Dockerfile so the subprocess-based encode path works without extra config.
-imageio[ffmpeg]>=2.31.0
+# Video generation (LTXV 2B distilled image-to-video)
 numpy>=1.26.0

--- a/flux-klein-server/server.py
+++ b/flux-klein-server/server.py
@@ -91,9 +91,17 @@ async def websocket_stream(ws: WebSocket):
     client_id = id(ws)
     logger.info("Client %d connected", client_id)
 
-    # Send initial status
+    # Send initial status. Include video_ready so the client knows whether
+    # LTXV animation is available for this session.
+    def _ready_status() -> dict:
+        return {
+            "type": "status",
+            "status": "ready",
+            "video_ready": video_pipeline.ready,
+        }
+
     if pipeline.ready:
-        await ws.send_text(json.dumps({"type": "status", "status": "ready"}))
+        await ws.send_text(json.dumps(_ready_status()))
     else:
         await ws.send_text(json.dumps({
             "type": "status",
@@ -102,7 +110,7 @@ async def websocket_stream(ws: WebSocket):
         }))
         while not pipeline.ready:
             await asyncio.sleep(0.5)
-        await ws.send_text(json.dumps({"type": "status", "status": "ready"}))
+        await ws.send_text(json.dumps(_ready_status()))
 
     # Per-connection state. Default seed is random-per-session (not per-frame)
     # so output is stable when the sketch doesn't change. Client can override.
@@ -281,7 +289,7 @@ async def websocket_stream(ws: WebSocket):
 
         # Stream decoded frames one at a time so the client can start playback
         # before the MP4 arrives. If cancelled between frames, bail out.
-        for i, frame in enumerate(frames):
+        for frame in frames:
             if done or video_cancel_event.is_set():
                 if not done:
                     try:

--- a/flux-klein-server/server.py
+++ b/flux-klein-server/server.py
@@ -7,19 +7,30 @@ Protocol:
 
   Server -> Client:
     - Text frame (JSON): { "type": "status", "status": "ready" | "warmup" | "error", "message": "..." }
-    - Binary frame: Generated JPEG bytes
+    - Binary frame: Generated JPEG bytes (img2img result)
+    - Text frame (JSON): { "type": "video_frame", "data": "<base64 JPEG>" } — one
+      per decoded LTXV animation frame, sent while the user is idle
+    - Text frame (JSON): { "type": "video_complete", "data": "<base64 MP4>" }
+    - Text frame (JSON): { "type": "video_cancelled" }
 
 Frame dropping:
   The client may send frames faster than the server can generate (~1 FPS).
   Only the latest frame is kept; older frames are dropped. This prevents
   frame queue buildup and keeps the output responsive to the current sketch.
+
+Video generation:
+  When the input buffer is empty and we have a last-generated still,
+  `video_loop` kicks off LTXV animation on the GPU. Arrival of a new
+  input frame cancels the in-flight video generation.
 """
 
 import asyncio
+import base64
 import io
 import json
 import logging
 import random
+import threading
 import time
 from contextlib import asynccontextmanager
 
@@ -29,6 +40,12 @@ from PIL import Image
 
 import config
 from pipeline import FluxKleinPipeline
+from video_pipeline import (
+    LtxvVideoPipeline,
+    VideoCancelled,
+    encode_mp4,
+    frames_to_jpeg,
+)
 
 logging.basicConfig(
     level=logging.INFO,
@@ -36,14 +53,21 @@ logging.basicConfig(
 )
 logger = logging.getLogger(__name__)
 
-pipeline = FluxKleinPipeline()
+# Shared serialization point across FLUX and LTXV — PyTorch isn't thread-safe
+# and both pipelines would otherwise interleave CUDA kernels on the same stream.
+gpu_lock = threading.Lock()
+
+pipeline = FluxKleinPipeline(gpu_lock)
+video_pipeline = LtxvVideoPipeline(gpu_lock)
 
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
-    """Load the model on startup."""
+    """Load the model(s) on startup."""
     logger.info("Starting FLUX.2-klein server...")
     pipeline.load()
+    # LTXV is optional — if it fails to load, the server still serves img2img.
+    video_pipeline.load()
     yield
     logger.info("Shutting down.")
 
@@ -54,6 +78,7 @@ app = FastAPI(lifespan=lifespan)
 @app.get("/health")
 async def health():
     info = pipeline.get_info()
+    info.update(video_pipeline.get_info())
     return {
         "status": "ok" if pipeline.ready else "loading",
         **info,
@@ -98,6 +123,17 @@ async def websocket_stream(ws: WebSocket):
     session_start = time.time()
     done = False
 
+    # ── Video-generation state (LTXV) ────────────────────────────────────
+    # The most recent generated still, used as the first-frame keyframe for
+    # video generation. Reset whenever a new img2img result is produced.
+    last_generated: Image.Image | None = None
+    # Guards against re-generating a video for the same still more than once.
+    video_done_for_last = False
+    # Set to abort an in-flight LTXV generation when a new sketch arrives.
+    video_cancel_event = threading.Event()
+    video_task: asyncio.Task | None = None
+    videos_generated = 0
+
     async def receive_loop():
         """Read messages from the client. Keep only the latest binary frame."""
         nonlocal latest_frame, frames_received, frames_dropped, done, current_config
@@ -139,19 +175,24 @@ async def websocket_stream(ws: WebSocket):
                         frames_dropped += 1
                     latest_frame = message["bytes"]
                     frames_received += 1
+                    # User is drawing again — abort any running video generation.
+                    video_cancel_event.set()
                     frame_event.set()
 
         except WebSocketDisconnect:
             done = True
+            video_cancel_event.set()
             frame_event.set()
         except Exception as e:
             logger.error("Client %d receive error: %s", client_id, e)
             done = True
+            video_cancel_event.set()
             frame_event.set()
 
     async def process_loop():
         """Process the latest frame whenever one is available."""
         nonlocal latest_frame, frames_processed, done
+        nonlocal last_generated, video_done_for_last
 
         while not done:
             await frame_event.wait()
@@ -168,10 +209,18 @@ async def websocket_stream(ws: WebSocket):
 
             try:
                 cfg = dict(current_config)
-                result_jpeg = await asyncio.to_thread(_process_frame, jpeg_data, cfg)
+                result_jpeg, result_image = await asyncio.to_thread(
+                    _process_frame, jpeg_data, cfg
+                )
                 if not done:
                     await ws.send_bytes(result_jpeg)
                     frames_processed += 1
+                    # Stash the PIL result as the keyframe for any future video
+                    # generation. Reset the once-per-still guard + cancel flag
+                    # so the video loop can pick it up on the next idle window.
+                    last_generated = result_image
+                    video_done_for_last = False
+                    video_cancel_event.clear()
             except Exception as e:
                 logger.error("Frame processing error: %s", e, exc_info=True)
                 if not done:
@@ -184,24 +233,137 @@ async def websocket_stream(ws: WebSocket):
                     except Exception:
                         pass
 
-    # Run both loops concurrently
+    async def run_video_generation():
+        """Generate an LTXV animation for the current `last_generated` still
+        and stream frames + MP4 back to the client. Any new sketch arriving
+        during generation aborts via `video_cancel_event`."""
+        nonlocal videos_generated, video_done_for_last
+
+        if last_generated is None:
+            return
+        keyframe = last_generated
+        prompt = str(current_config.get("prompt") or "")
+        seed = current_config.get("seed")
+
+        logger.info(
+            "Client %d: starting LTXV animation (prompt='%s', %d frames, %dx%d)",
+            client_id, prompt[:50], config.LTXV_NUM_FRAMES,
+            config.LTXV_WIDTH, config.LTXV_HEIGHT,
+        )
+        t0 = time.time()
+
+        try:
+            frames = await asyncio.to_thread(
+                video_pipeline.generate,
+                keyframe, prompt, video_cancel_event, seed,
+            )
+        except VideoCancelled:
+            logger.info("Client %d: LTXV cancelled by user", client_id)
+            if not done:
+                try:
+                    await ws.send_text(json.dumps({"type": "video_cancelled"}))
+                except Exception:
+                    pass
+            return
+        except Exception as e:  # noqa: BLE001
+            logger.error("Client %d: LTXV error: %s", client_id, e, exc_info=True)
+            return
+
+        if done or video_cancel_event.is_set():
+            return
+
+        # Stream decoded frames one at a time so the client can start playback
+        # before the MP4 arrives. If cancelled between frames, bail out.
+        for i, frame in enumerate(frames):
+            if done or video_cancel_event.is_set():
+                if not done:
+                    try:
+                        await ws.send_text(json.dumps({"type": "video_cancelled"}))
+                    except Exception:
+                        pass
+                return
+            try:
+                jpeg = frames_to_jpeg(frame, quality=config.OUTPUT_JPEG_QUALITY)
+                await ws.send_text(json.dumps({
+                    "type": "video_frame",
+                    "data": base64.b64encode(jpeg).decode("ascii"),
+                }))
+            except Exception as e:  # noqa: BLE001
+                logger.warning("Client %d: video_frame send failed: %s", client_id, e)
+                return
+
+        # Encode the full MP4 for smooth looping on the client.
+        try:
+            mp4 = await asyncio.to_thread(
+                encode_mp4, frames, config.LTXV_FPS, config.LTXV_OUTPUT_CRF,
+            )
+            if done:
+                return
+            await ws.send_text(json.dumps({
+                "type": "video_complete",
+                "data": base64.b64encode(mp4).decode("ascii"),
+            }))
+            video_done_for_last = True
+            videos_generated += 1
+            logger.info(
+                "Client %d: LTXV done in %.1fs (%d frames, %d bytes MP4)",
+                client_id, time.time() - t0, len(frames), len(mp4),
+            )
+        except Exception as e:  # noqa: BLE001
+            logger.error("Client %d: MP4 encode failed: %s", client_id, e, exc_info=True)
+
+    async def video_loop():
+        """Poll for idle windows (no input frame, no in-flight generation) and
+        kick off LTXV animation. Runs concurrently with receive/process loops."""
+        nonlocal video_task
+
+        if not video_pipeline.ready:
+            return
+        # Small wait so the initial warmup img2img frame has a chance to land.
+        await asyncio.sleep(0.5)
+        while not done:
+            await asyncio.sleep(0.1)
+            if done:
+                break
+            if latest_frame is not None:
+                continue
+            if last_generated is None:
+                continue
+            if video_done_for_last:
+                continue
+            if video_task is not None and not video_task.done():
+                continue
+            # Clear the abort flag just before we launch so stale signals from
+            # the previous generation don't carry over.
+            video_cancel_event.clear()
+            video_task = asyncio.create_task(run_video_generation())
+
+    # Run all loops concurrently
     try:
-        await asyncio.gather(receive_loop(), process_loop())
+        await asyncio.gather(receive_loop(), process_loop(), video_loop())
     except Exception as e:
         logger.error("WebSocket error for client %d: %s", client_id, e, exc_info=True)
     finally:
+        # Make sure any in-flight video generation stops cleanly.
+        video_cancel_event.set()
+        if video_task is not None and not video_task.done():
+            video_task.cancel()
         elapsed = time.time() - session_start
         fps = frames_processed / elapsed if elapsed > 0 else 0
         logger.info(
-            "Client %d disconnected. Received %d, processed %d, dropped %d, %.1f FPS over %.1fs",
-            client_id, frames_received, frames_processed, frames_dropped, fps, elapsed,
+            "Client %d disconnected. Received %d, processed %d, dropped %d, "
+            "videos %d, %.1f FPS over %.1fs",
+            client_id, frames_received, frames_processed, frames_dropped,
+            videos_generated, fps, elapsed,
         )
 
 
-def _process_frame(jpeg_data: bytes, cfg: dict) -> bytes:
+def _process_frame(jpeg_data: bytes, cfg: dict) -> tuple[bytes, Image.Image]:
     """Decode JPEG, run through pipeline, encode result as JPEG.
 
-    Runs in a thread to avoid blocking the event loop.
+    Returns the encoded JPEG bytes plus the PIL result so the caller can
+    reuse it as a keyframe for subsequent LTXV animation. Runs in a thread
+    to avoid blocking the event loop.
     """
     image = Image.open(io.BytesIO(jpeg_data)).convert("RGB")
     image = image.resize((config.DEFAULT_WIDTH, config.DEFAULT_HEIGHT), Image.LANCZOS)
@@ -215,7 +377,7 @@ def _process_frame(jpeg_data: bytes, cfg: dict) -> bytes:
 
     buffer = io.BytesIO()
     output.save(buffer, format="JPEG", quality=config.OUTPUT_JPEG_QUALITY)
-    return buffer.getvalue()
+    return buffer.getvalue(), output
 
 
 if __name__ == "__main__":

--- a/flux-klein-server/server.py
+++ b/flux-klein-server/server.py
@@ -216,11 +216,18 @@ async def websocket_stream(ws: WebSocket):
                     await ws.send_bytes(result_jpeg)
                     frames_processed += 1
                     # Stash the PIL result as the keyframe for any future video
-                    # generation. Reset the once-per-still guard + cancel flag
-                    # so the video loop can pick it up on the next idle window.
+                    # generation. Reset the once-per-still guard so the video
+                    # loop can pick this still up on the next idle window.
+                    #
+                    # NOTE: do NOT clear `video_cancel_event` here. The previous
+                    # in-flight video task's per-step callback may not have
+                    # observed the set yet — clearing now would let it complete
+                    # for the *previous* still and incorrectly mark
+                    # `video_done_for_last`. `video_loop` clears the flag itself
+                    # right before launching the next task, after confirming any
+                    # prior task is done.
                     last_generated = result_image
                     video_done_for_last = False
-                    video_cancel_event.clear()
             except Exception as e:
                 logger.error("Frame processing error: %s", e, exc_info=True)
                 if not done:

--- a/flux-klein-server/video_pipeline.py
+++ b/flux-klein-server/video_pipeline.py
@@ -1,0 +1,191 @@
+"""LTXV 2B distilled image-to-video pipeline.
+
+Runs alongside the FLUX img2img pipeline on the same GPU. When the user stops
+drawing (input buffer goes idle), the server feeds the last generated still
+into this pipeline as a keyframe and streams back frames + a looping MP4.
+
+Kept deliberately minimal — resolution, frame count, and step count are
+tuned for speed (SLA: <5s time-to-first-playback), not quality.
+"""
+
+import io
+import logging
+import subprocess
+import tempfile
+import threading
+import time
+from pathlib import Path
+
+import torch
+from PIL import Image
+
+import config
+
+logger = logging.getLogger(__name__)
+
+
+class VideoCancelled(Exception):
+    """Raised from the per-step callback to abort a running LTXV generation
+    when the user resumes drawing. Caller should suppress this and treat it
+    as a normal cancellation, not an error."""
+
+
+class LtxvVideoPipeline:
+    """Wraps LTX-Video 2B distilled for image-to-video generation.
+
+    The pipeline is loaded once at pod startup and reused across all client
+    connections. Concurrent access is serialized via `gpu_lock` (passed in
+    by the server so FLUX and LTXV can't run at the same time on the same
+    CUDA stream).
+    """
+
+    def __init__(self, gpu_lock: threading.Lock):
+        self.pipe = None
+        self._ready = False
+        self._dtype = getattr(torch, config.LTXV_DTYPE)
+        self._gpu_lock = gpu_lock
+
+    @property
+    def ready(self) -> bool:
+        return self._ready
+
+    def load(self) -> None:
+        if not config.ENABLE_VIDEO:
+            logger.info("Video generation disabled (KIKI_ENABLE_VIDEO=0); skipping LTXV load")
+            return
+
+        logger.info("Loading LTXV model: %s (dtype=%s)", config.LTXV_MODEL_ID, config.LTXV_DTYPE)
+        t0 = time.time()
+
+        try:
+            from diffusers import LTXImageToVideoPipeline
+
+            self.pipe = LTXImageToVideoPipeline.from_pretrained(
+                config.LTXV_MODEL_ID,
+                torch_dtype=self._dtype,
+            ).to("cuda")
+
+            # A tiny warmup so the first user-facing call doesn't pay the
+            # CUDA graph / kernel compilation cost.
+            logger.info("Warming up LTXV...")
+            t1 = time.time()
+            warmup_image = Image.new("RGB", (config.LTXV_WIDTH, config.LTXV_HEIGHT), "gray")
+            with self._gpu_lock:
+                _ = self.pipe(
+                    image=warmup_image,
+                    prompt="warmup",
+                    num_frames=config.LTXV_NUM_FRAMES,
+                    num_inference_steps=config.LTXV_STEPS,
+                    guidance_scale=config.LTXV_GUIDANCE,
+                    width=config.LTXV_WIDTH,
+                    height=config.LTXV_HEIGHT,
+                    generator=torch.Generator(device="cuda").manual_seed(0),
+                )
+            logger.info("LTXV warmup done (%.1fs)", time.time() - t1)
+            self._ready = True
+            logger.info("LTXV ready. Total init: %.1fs", time.time() - t0)
+        except Exception as e:  # noqa: BLE001 — want fail-soft so FLUX still serves
+            logger.error("LTXV load failed (%s: %s); video generation disabled", type(e).__name__, e)
+            self.pipe = None
+            self._ready = False
+
+    def generate(
+        self,
+        image: Image.Image,
+        prompt: str,
+        cancel_event: threading.Event,
+        seed: int | None = None,
+    ) -> list[Image.Image]:
+        """Generate an image-to-video animation.
+
+        Returns the list of decoded frames (PIL images). If `cancel_event`
+        is set between steps, raises `VideoCancelled` — the caller should
+        catch this and treat it as a normal abort.
+        """
+        if not self._ready or self.pipe is None:
+            raise RuntimeError("LTXV pipeline not ready")
+
+        # LTX expects the keyframe to be resized to the generation resolution.
+        keyframe = image.convert("RGB").resize(
+            (config.LTXV_WIDTH, config.LTXV_HEIGHT), Image.LANCZOS
+        )
+
+        # Per-step cancel check. Runs on the GPU thread between denoising
+        # steps; raising aborts the pipeline call.
+        def step_cancel(pipe, step_index, timestep, callback_kwargs):
+            if cancel_event.is_set():
+                raise VideoCancelled()
+            return callback_kwargs
+
+        generator = (
+            torch.Generator(device="cuda").manual_seed(seed) if seed is not None else None
+        )
+
+        with self._gpu_lock:
+            if cancel_event.is_set():
+                raise VideoCancelled()
+            result = self.pipe(
+                image=keyframe,
+                prompt=prompt or "",
+                num_frames=config.LTXV_NUM_FRAMES,
+                num_inference_steps=config.LTXV_STEPS,
+                guidance_scale=config.LTXV_GUIDANCE,
+                width=config.LTXV_WIDTH,
+                height=config.LTXV_HEIGHT,
+                generator=generator,
+                callback_on_step_end=step_cancel,
+                output_type="pil",
+            )
+
+        # diffusers returns `frames` as a list of lists (batch dim).
+        frames = result.frames[0] if hasattr(result, "frames") else result.videos[0]
+        return list(frames)
+
+    def get_info(self) -> dict:
+        return {
+            "video_enabled": config.ENABLE_VIDEO,
+            "video_ready": self._ready,
+            "video_model": config.LTXV_MODEL_ID if self._ready else None,
+            "video_resolution": f"{config.LTXV_WIDTH}x{config.LTXV_HEIGHT}",
+            "video_num_frames": config.LTXV_NUM_FRAMES,
+        }
+
+
+def frames_to_jpeg(frame: Image.Image, quality: int = 80) -> bytes:
+    buf = io.BytesIO()
+    frame.save(buf, format="JPEG", quality=quality)
+    return buf.getvalue()
+
+
+def encode_mp4(frames: list[Image.Image], fps: int, crf: int) -> bytes:
+    """Encode a list of PIL frames into an H.264 MP4 blob via ffmpeg.
+
+    Writes frames as PNGs to a tempdir and invokes ffmpeg once. ~200–500ms
+    overhead for a short clip — acceptable within the <5s SLA.
+    """
+    if not frames:
+        raise ValueError("encode_mp4: no frames")
+
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp_path = Path(tmp)
+        for i, f in enumerate(frames):
+            f.save(tmp_path / f"frame_{i:05d}.png")
+        out_path = tmp_path / "out.mp4"
+
+        # yuv420p + even dimensions needed for AVPlayer/Safari compatibility.
+        subprocess.run(
+            [
+                "ffmpeg",
+                "-loglevel", "error",
+                "-y",
+                "-framerate", str(fps),
+                "-i", str(tmp_path / "frame_%05d.png"),
+                "-c:v", "libx264",
+                "-pix_fmt", "yuv420p",
+                "-crf", str(crf),
+                "-movflags", "+faststart",
+                str(out_path),
+            ],
+            check=True,
+        )
+        return out_path.read_bytes()

--- a/flux-klein-server/video_pipeline.py
+++ b/flux-klein-server/video_pipeline.py
@@ -1,8 +1,13 @@
-"""LTXV 2B distilled image-to-video pipeline.
+"""LTXV 2B 0.9.8 distilled image-to-video pipeline.
 
 Runs alongside the FLUX img2img pipeline on the same GPU. When the user stops
 drawing (input buffer goes idle), the server feeds the last generated still
 into this pipeline as a keyframe and streams back frames + a looping MP4.
+
+Uses LTXConditionPipeline (0.9.5+ API) with the 2B 0.9.8 distilled
+transformer loaded from a single-file checkpoint. Weights are stored in FP8
+(float8_e4m3fn) via enable_layerwise_casting for lower VRAM and faster
+inference on Blackwell tensor cores; compute stays in BF16.
 
 Kept deliberately minimal — resolution, frame count, and step count are
 tuned for speed (SLA: <5s time-to-first-playback), not quality.
@@ -31,7 +36,7 @@ class VideoCancelled(Exception):
 
 
 class LtxvVideoPipeline:
-    """Wraps LTX-Video 2B distilled for image-to-video generation.
+    """Wraps LTX-Video 2B 0.9.8 distilled for image-to-video generation.
 
     The pipeline is loaded once at pod startup and reused across all client
     connections. Concurrent access is serialized via `gpu_lock` (passed in
@@ -54,33 +59,50 @@ class LtxvVideoPipeline:
             logger.info("Video generation disabled (KIKI_ENABLE_VIDEO=0); skipping LTXV load")
             return
 
-        logger.info("Loading LTXV model: %s (dtype=%s)", config.LTXV_MODEL_ID, config.LTXV_DTYPE)
+        logger.info(
+            "Loading LTXV 2B 0.9.8 distilled (base=%s, transformer=%s/%s)",
+            config.LTXV_BASE_REPO, config.LTXV_TRANSFORMER_REPO,
+            config.LTXV_TRANSFORMER_FILE,
+        )
         t0 = time.time()
 
         try:
-            from diffusers import LTXImageToVideoPipeline
+            from diffusers import AutoModel, LTXConditionPipeline
 
-            self.pipe = LTXImageToVideoPipeline.from_pretrained(
-                config.LTXV_MODEL_ID,
+            # Load the 2B transformer from the pre-quantized FP8 checkpoint.
+            # from_single_file upcasts to BF16 on load; we then apply
+            # layerwise_casting to store FP8 / compute BF16 for inference.
+            logger.info("Loading transformer from single file...")
+            transformer = AutoModel.from_single_file(
+                f"https://huggingface.co/{config.LTXV_TRANSFORMER_REPO}/blob/main/{config.LTXV_TRANSFORMER_FILE}",
+                config=config.LTXV_BASE_REPO,
+                subfolder="transformer",
+                torch_dtype=self._dtype,
+            )
+
+            logger.info("Applying FP8 layerwise casting...")
+            transformer.enable_layerwise_casting(
+                storage_dtype=torch.float8_e4m3fn,
+                compute_dtype=torch.bfloat16,
+            )
+
+            # Assemble the full pipeline from the 0.9.5 repo (VAE, text
+            # encoder, scheduler) with our transformer swapped in.
+            logger.info("Assembling pipeline from %s...", config.LTXV_BASE_REPO)
+            self.pipe = LTXConditionPipeline.from_pretrained(
+                config.LTXV_BASE_REPO,
+                transformer=transformer,
                 torch_dtype=self._dtype,
             ).to("cuda")
+            self.pipe.vae.enable_tiling()
 
-            # A tiny warmup so the first user-facing call doesn't pay the
-            # CUDA graph / kernel compilation cost.
+            # Warmup so the first user-facing call doesn't pay CUDA graph /
+            # kernel compilation cost.
             logger.info("Warming up LTXV...")
             t1 = time.time()
             warmup_image = Image.new("RGB", (config.LTXV_WIDTH, config.LTXV_HEIGHT), "gray")
             with self._gpu_lock:
-                _ = self.pipe(
-                    image=warmup_image,
-                    prompt="warmup",
-                    num_frames=config.LTXV_NUM_FRAMES,
-                    num_inference_steps=config.LTXV_STEPS,
-                    guidance_scale=config.LTXV_GUIDANCE,
-                    width=config.LTXV_WIDTH,
-                    height=config.LTXV_HEIGHT,
-                    generator=torch.Generator(device="cuda").manual_seed(0),
-                )
+                self._run_generation(warmup_image, "warmup", None, 0)
             logger.info("LTXV warmup done (%.1fs)", time.time() - t1)
             self._ready = True
             logger.info("LTXV ready. Total init: %.1fs", time.time() - t0)
@@ -88,6 +110,56 @@ class LtxvVideoPipeline:
             logger.error("LTXV load failed (%s: %s); video generation disabled", type(e).__name__, e)
             self.pipe = None
             self._ready = False
+
+    def _run_generation(
+        self,
+        image: Image.Image,
+        prompt: str,
+        cancel_event: threading.Event | None,
+        seed: int | None,
+    ) -> list[Image.Image]:
+        """Inner generation call — assumes gpu_lock is held."""
+        from diffusers.pipelines.ltx.pipeline_ltx_condition import LTXVideoCondition
+        from diffusers.utils import export_to_video, load_video
+
+        # LTXConditionPipeline expects video-codec-compressed conditioning.
+        # Export the single image as a 1-frame video, then load it back.
+        keyframe = image.convert("RGB").resize(
+            (config.LTXV_WIDTH, config.LTXV_HEIGHT), Image.LANCZOS
+        )
+        with tempfile.NamedTemporaryFile(suffix=".mp4", delete=True) as tmp:
+            export_to_video([keyframe], tmp.name, fps=config.LTXV_FPS)
+            video_cond = load_video(tmp.name)
+        condition = LTXVideoCondition(video=video_cond, frame_index=0)
+
+        # Per-step cancel check.
+        def step_cancel(pipe, step_index, timestep, callback_kwargs):
+            if cancel_event is not None and cancel_event.is_set():
+                raise VideoCancelled()
+            return callback_kwargs
+
+        generator = (
+            torch.Generator(device="cuda").manual_seed(seed) if seed is not None else None
+        )
+
+        result = self.pipe(
+            conditions=[condition],
+            prompt=prompt or "",
+            negative_prompt="worst quality, inconsistent motion, blurry, jittery, distorted",
+            width=config.LTXV_WIDTH,
+            height=config.LTXV_HEIGHT,
+            num_frames=config.LTXV_NUM_FRAMES,
+            timesteps=config.LTXV_TIMESTEPS,
+            guidance_scale=config.LTXV_GUIDANCE,
+            decode_timestep=0.05,
+            decode_noise_scale=0.025,
+            generator=generator,
+            callback_on_step_end=step_cancel,
+            output_type="pil",
+        )
+
+        frames = result.frames[0] if hasattr(result, "frames") else result.videos[0]
+        return list(frames)
 
     def generate(
         self,
@@ -105,47 +177,16 @@ class LtxvVideoPipeline:
         if not self._ready or self.pipe is None:
             raise RuntimeError("LTXV pipeline not ready")
 
-        # LTX expects the keyframe to be resized to the generation resolution.
-        keyframe = image.convert("RGB").resize(
-            (config.LTXV_WIDTH, config.LTXV_HEIGHT), Image.LANCZOS
-        )
-
-        # Per-step cancel check. Runs on the GPU thread between denoising
-        # steps; raising aborts the pipeline call.
-        def step_cancel(pipe, step_index, timestep, callback_kwargs):
-            if cancel_event.is_set():
-                raise VideoCancelled()
-            return callback_kwargs
-
-        generator = (
-            torch.Generator(device="cuda").manual_seed(seed) if seed is not None else None
-        )
-
         with self._gpu_lock:
             if cancel_event.is_set():
                 raise VideoCancelled()
-            result = self.pipe(
-                image=keyframe,
-                prompt=prompt or "",
-                num_frames=config.LTXV_NUM_FRAMES,
-                num_inference_steps=config.LTXV_STEPS,
-                guidance_scale=config.LTXV_GUIDANCE,
-                width=config.LTXV_WIDTH,
-                height=config.LTXV_HEIGHT,
-                generator=generator,
-                callback_on_step_end=step_cancel,
-                output_type="pil",
-            )
-
-        # diffusers returns `frames` as a list of lists (batch dim).
-        frames = result.frames[0] if hasattr(result, "frames") else result.videos[0]
-        return list(frames)
+            return self._run_generation(image, prompt, cancel_event, seed)
 
     def get_info(self) -> dict:
         return {
             "video_enabled": config.ENABLE_VIDEO,
             "video_ready": self._ready,
-            "video_model": config.LTXV_MODEL_ID if self._ready else None,
+            "video_model": "ltxv-2b-0.9.8-distilled-fp8" if self._ready else None,
             "video_resolution": f"{config.LTXV_WIDTH}x{config.LTXV_HEIGHT}",
             "video_num_frames": config.LTXV_NUM_FRAMES,
         }

--- a/ios/Kiki/App/AppCoordinator.swift
+++ b/ios/Kiki/App/AppCoordinator.swift
@@ -156,6 +156,12 @@ final class AppCoordinator {
     // MARK: - Private State
 
     private var lastSuccessfulImage: UIImage?
+    /// Temp-file URL of the most recent looping MP4. Kept so we can delete
+    /// the previous one when a new animation arrives.
+    private var currentVideoURL: URL?
+    /// Number of video frames received in the current LTXV generation.
+    /// Reset when a new still is generated or drawing resumes.
+    private var videoFramesReceived = 0
     private var canvasObservationTask: Task<Void, Never>?
 
     // MARK: - Lifecycle
@@ -476,6 +482,9 @@ final class AppCoordinator {
             guard let self else { return }
             self.streamFrameCount += 1
             self.lastSuccessfulImage = image
+            // A new still arrived — any in-flight video for the previous still
+            // is obsolete. Reset counters and drop the old MP4 file.
+            self.resetVideoPlayback()
             self.resultState = .streaming(image: image, frameCount: self.streamFrameCount)
             if self.drawingLayout == .fullscreen {
                 self.showFloatingPanel = true
@@ -485,6 +494,10 @@ final class AppCoordinator {
             if count == 1 || count % 30 == 0 {
                 print("[Stream] Received frame \(count)")
             }
+        }
+
+        session.onVideoEvent = { [weak self] event in
+            self?.handleVideoEvent(event)
         }
 
         session.onConnectionStateChanged = { [weak self] state in
@@ -511,6 +524,7 @@ final class AppCoordinator {
         streamSession = nil
         streamConnectionState = .disconnected
         streamFrameCount = 0
+        resetVideoPlayback()
 
         if let image = lastSuccessfulImage {
             resultState = .preview(image: image)
@@ -599,6 +613,63 @@ final class AppCoordinator {
         case .connected, .disconnected:
             resultState = .empty
         }
+
+        // Now that the view is detached, it's safe to remove the temp MP4.
+        if let url = currentVideoURL {
+            try? FileManager.default.removeItem(at: url)
+            currentVideoURL = nil
+        }
+    }
+
+    // MARK: - Video Playback
+
+    private func handleVideoEvent(_ event: StreamWebSocketClient.VideoEvent) {
+        // Only render animation over a still we've actually generated.
+        // Without a `baseImage`, Constraint #2 (never clear the right pane)
+        // would be violated by a bare video frame on gray.
+        guard let base = lastSuccessfulImage else { return }
+
+        switch event {
+        case .frame(let jpegData):
+            guard let frame = UIImage(data: jpegData) else { return }
+            videoFramesReceived += 1
+            resultState = .videoStreaming(
+                baseImage: base,
+                latestFrame: frame,
+                framesReceived: videoFramesReceived
+            )
+
+        case .complete(let mp4Data):
+            // Persist to a temp file so AVPlayer can stream it from disk.
+            do {
+                let url = FileManager.default.temporaryDirectory
+                    .appendingPathComponent("kiki-anim-\(UUID().uuidString).mp4")
+                try mp4Data.write(to: url, options: .atomic)
+                // Clean up any previous video file.
+                if let old = currentVideoURL {
+                    try? FileManager.default.removeItem(at: old)
+                }
+                currentVideoURL = url
+                resultState = .videoLooping(mp4URL: url, fallbackImage: base)
+            } catch {
+                streamLog.error("Failed to write video to temp file: \(error.localizedDescription)")
+                // Fall back to the last still; drop the video silently.
+                resultState = .preview(image: base)
+            }
+
+        case .cancelled:
+            resetVideoPlayback()
+            // After cancellation, the pod will typically start sending img2img
+            // frames again. Keep the last still visible until then.
+            resultState = .streaming(image: base, frameCount: streamFrameCount)
+        }
+    }
+
+    /// Reset the streaming-frame counter. The MP4 file is left on disk so
+    /// SwiftUI can finish tearing down the AVPlayer view before we remove it
+    /// (done on `stopStream()` or when a new animation overwrites it).
+    private func resetVideoPlayback() {
+        videoFramesReceived = 0
     }
 
     /// Push the current config to the stream session. The capture loop will

--- a/ios/Kiki/App/AppCoordinator.swift
+++ b/ios/Kiki/App/AppCoordinator.swift
@@ -139,6 +139,10 @@ final class AppCoordinator {
     private var streamSession: StreamSession?
     private(set) var streamConnectionState: StreamSession.ConnectionState = .disconnected
     private(set) var streamFrameCount = 0
+    /// Whether the pod's LTXV video pipeline is available. `nil` until the
+    /// server reports its status; `false` if LTXV failed to load (e.g.
+    /// weights missing from the network volume).
+    private(set) var videoAvailable: Bool?
 
     // -- Stream parameters --
 
@@ -500,6 +504,10 @@ final class AppCoordinator {
             self?.handleVideoEvent(event)
         }
 
+        session.onVideoReadyChanged = { [weak self] ready in
+            self?.videoAvailable = ready
+        }
+
         session.onConnectionStateChanged = { [weak self] state in
             guard let self else { return }
             streamLog.info("Connection state changed: \(String(describing: state))")
@@ -524,6 +532,7 @@ final class AppCoordinator {
         streamSession = nil
         streamConnectionState = .disconnected
         streamFrameCount = 0
+        videoAvailable = nil
         resetVideoPlayback()
 
         if let image = lastSuccessfulImage {

--- a/ios/Kiki/App/StreamSession.swift
+++ b/ios/Kiki/App/StreamSession.swift
@@ -34,6 +34,7 @@ final class StreamSession {
     private var captureTask: Task<Void, Never>?
     private var receiveTask: Task<Void, Never>?
     private var statusTask: Task<Void, Never>?
+    private var videoTask: Task<Void, Never>?
     private var reconnectTask: Task<Void, Never>?
 
     /// How often to capture and send frames (default ~2 FPS for FLUX.2-klein).
@@ -46,11 +47,22 @@ final class StreamSession {
     /// Last config actually sent to the server (used for change detection).
     private var lastSentConfig: StreamConfig?
 
+    /// `strokeCount` of the canvas snapshot at the last successful frame send.
+    /// If the current snapshot's `strokeCount` matches, the canvas hasn't
+    /// changed — skip the send so the pod's input buffer goes idle and can
+    /// switch to video generation. Reset to `nil` whenever config changes so
+    /// the unchanged sketch re-renders under the new prompt.
+    private var lastSentStrokeCount: Int?
+
     /// Current connection state, observed by AppCoordinator.
     private(set) var connectionState: ConnectionState = .disconnected
 
     /// Called when a new generated image frame is received.
     var onImageReceived: ((UIImage) -> Void)?
+
+    /// Called when the pod emits a video-animation event (LTXV-generated
+    /// animation of the last generated still, played while the user is idle).
+    var onVideoEvent: ((StreamWebSocketClient.VideoEvent) -> Void)?
 
     /// Called when connection state changes.
     var onConnectionStateChanged: ((ConnectionState) -> Void)?
@@ -95,6 +107,7 @@ final class StreamSession {
         self.reconnectAttempts = 0
         self.framesSent = 0
         self.framesReceived = 0
+        self.lastSentStrokeCount = nil
 
         await connectAndRun()
     }
@@ -123,6 +136,7 @@ final class StreamSession {
             print("[Stream] Initial config sent")
 
             startReceiveLoop()
+            startVideoLoop()
             startCaptureLoop()
         } catch {
             print("[Stream] Connection failed: \(error)")
@@ -170,15 +184,23 @@ final class StreamSession {
                 // Send config update if it changed since last send
                 await self.sendConfigIfChanged()
 
-                let jpeg: Data? = await MainActor.run {
+                let result: (Data, Int)? = await MainActor.run {
                     guard let snapshot = self.canvasViewModel.captureSnapshot() else { return nil }
+                    // Dirty check: skip if the canvas hasn't changed since the
+                    // last successful send. `strokeCount` increments on every
+                    // stroke-end, erase, undo, redo, clear, and background change.
+                    if snapshot.strokeCount == self.lastSentStrokeCount {
+                        return nil
+                    }
                     guard let resized = self.resizeImage(snapshot.image, to: Self.captureSize) else { return nil }
-                    return resized.jpegData(compressionQuality: 0.7)
+                    guard let data = resized.jpegData(compressionQuality: 0.7) else { return nil }
+                    return (data, snapshot.strokeCount)
                 }
 
-                if let jpeg {
+                if let (jpeg, strokeCount) = result {
                     do {
                         try await self.client.sendFrame(jpeg)
+                        await MainActor.run { self.lastSentStrokeCount = strokeCount }
                         count += 1
                         await self.setFramesSent(count)
                         if count == 1 || count % 30 == 0 {
@@ -188,7 +210,7 @@ final class StreamSession {
                         print("[Stream] Send error: \(error)")
                     }
                 } else if count == 0 {
-                    print("[Stream] captureSnapshot returned nil (canvas empty?)")
+                    print("[Stream] captureSnapshot returned nil or unchanged (canvas empty?)")
                 }
 
                 let interval = await self.captureInterval
@@ -199,12 +221,15 @@ final class StreamSession {
     }
 
     /// Compare current config to what was last sent; if different, send an update.
+    /// Also clears `lastSentStrokeCount` so the unchanged sketch gets re-sent
+    /// under the new prompt (the dirty check would otherwise suppress it).
     private func sendConfigIfChanged() async {
         let current = config
         guard current != lastSentConfig else { return }
         do {
             try await client.sendConfig(current)
             lastSentConfig = current
+            lastSentStrokeCount = nil
             print("[Stream] Config auto-sent: prompt=\(current.prompt ?? "(none)")")
         } catch {
             print("[Stream] Config send error: \(error)")
@@ -261,6 +286,21 @@ final class StreamSession {
         }
     }
 
+    // MARK: - Video Loop
+
+    private func startVideoLoop() {
+        videoTask = Task { [weak self] in
+            guard let self else { return }
+            let events = await client.videoEvents
+            for await event in events {
+                guard !Task.isCancelled else { break }
+                await MainActor.run {
+                    self.onVideoEvent?(event)
+                }
+            }
+        }
+    }
+
     // MARK: - Private
 
     private func setFramesSent(_ count: Int) {
@@ -278,6 +318,8 @@ final class StreamSession {
         receiveTask = nil
         statusTask?.cancel()
         statusTask = nil
+        videoTask?.cancel()
+        videoTask = nil
         reconnectTask?.cancel()
         reconnectTask = nil
     }

--- a/ios/Kiki/App/StreamSession.swift
+++ b/ios/Kiki/App/StreamSession.swift
@@ -64,6 +64,9 @@ final class StreamSession {
     /// animation of the last generated still, played while the user is idle).
     var onVideoEvent: ((StreamWebSocketClient.VideoEvent) -> Void)?
 
+    /// Called when the pod reports whether LTXV video generation is available.
+    var onVideoReadyChanged: ((Bool) -> Void)?
+
     /// Called when connection state changes.
     var onConnectionStateChanged: ((ConnectionState) -> Void)?
 
@@ -278,6 +281,10 @@ final class StreamSession {
                         // Re-send config now that the server is ready to accept it.
                         // The initial config may have been sent during provisioning.
                         self.lastSentConfig = nil
+                        // Surface video availability to the coordinator.
+                        if let videoReady = status.videoReady {
+                            self.onVideoReadyChanged?(videoReady)
+                        }
                     } else if (status.type == "status" && status.status == "error") || status.type == "error" {
                         self.updateConnectionState(.error(status.message ?? "Server error"))
                     }

--- a/ios/Kiki/Views/DrawingView.swift
+++ b/ios/Kiki/Views/DrawingView.swift
@@ -154,6 +154,12 @@ struct DrawingView: View {
                         .padding(.bottom, 16)
                 }
             }
+            .overlay(alignment: .bottomLeading) {
+                if coordinator.videoAvailable == false {
+                    videoUnavailableBadge
+                        .padding(12)
+                }
+            }
 
             Rectangle()
                 .fill(Color(.separator))
@@ -167,6 +173,15 @@ struct DrawingView: View {
     }
 
     // MARK: - Private
+
+    private var videoUnavailableBadge: some View {
+        Label("Video animation unavailable", systemImage: "film.circle")
+            .font(.caption2)
+            .foregroundStyle(.secondary)
+            .padding(.horizontal, 10)
+            .padding(.vertical, 6)
+            .background(.ultraThinMaterial, in: Capsule())
+    }
 
     private var streamSwapBar: some View {
         Button {

--- a/ios/Kiki/Views/FloatingResultPanel.swift
+++ b/ios/Kiki/Views/FloatingResultPanel.swift
@@ -107,6 +107,12 @@ struct FloatingResultPanel: View {
                 Color(.systemGray6)
             }
 
+        case .videoStreaming(_, let latestFrame, _):
+            pickableImage(latestFrame).padding(4)
+
+        case .videoLooping(_, let fallbackImage):
+            pickableImage(fallbackImage).padding(4)
+
         case .empty:
             Color(.systemGray6)
         }

--- a/ios/Packages/NetworkModule/Sources/NetworkModule/StreamWebSocketClient.swift
+++ b/ios/Packages/NetworkModule/Sources/NetworkModule/StreamWebSocketClient.swift
@@ -20,6 +20,19 @@ public actor StreamWebSocketClient {
         public let message: String?
     }
 
+    /// Video-generation messages from the pod. Emitted only while the pod is
+    /// idle and running LTXV animation on the last generated still. Any img2img
+    /// frame arriving on `receivedFrames` should cause the client to discard
+    /// in-flight video and revert to normal streaming display.
+    public enum VideoEvent: Sendable {
+        /// A single decoded video frame as JPEG. Sent as they are ready.
+        case frame(Data)
+        /// The complete animation as an MP4 blob, intended for smooth looping.
+        case complete(Data)
+        /// Pod aborted generation (user resumed drawing).
+        case cancelled
+    }
+
     // MARK: - Properties
 
     private let request: URLRequest
@@ -35,6 +48,9 @@ public actor StreamWebSocketClient {
     private let statusContinuation: AsyncStream<ServerStatus>.Continuation
     public let serverStatuses: AsyncStream<ServerStatus>
 
+    private let videoEventsContinuation: AsyncStream<VideoEvent>.Continuation
+    public let videoEvents: AsyncStream<VideoEvent>
+
     // MARK: - Lifecycle
 
     /// Create a client for a URL (no auth headers).
@@ -49,6 +65,10 @@ public actor StreamWebSocketClient {
         var statusCont: AsyncStream<ServerStatus>.Continuation!
         self.serverStatuses = AsyncStream { statusCont = $0 }
         self.statusContinuation = statusCont
+
+        var videoCont: AsyncStream<VideoEvent>.Continuation!
+        self.videoEvents = AsyncStream { videoCont = $0 }
+        self.videoEventsContinuation = videoCont
     }
 
     // MARK: - Connection
@@ -66,6 +86,10 @@ public actor StreamWebSocketClient {
         var statusCont: AsyncStream<ServerStatus>.Continuation!
         self.serverStatuses = AsyncStream { statusCont = $0 }
         self.statusContinuation = statusCont
+
+        var videoCont: AsyncStream<VideoEvent>.Continuation!
+        self.videoEvents = AsyncStream { videoCont = $0 }
+        self.videoEventsContinuation = videoCont
     }
 
     public func connect() async throws {
@@ -120,6 +144,7 @@ public actor StreamWebSocketClient {
         state = .disconnected
         framesContinuation.finish()
         statusContinuation.finish()
+        videoEventsContinuation.finish()
     }
 
     // MARK: - Sending
@@ -164,6 +189,14 @@ public actor StreamWebSocketClient {
                             if type == "frame", let b64 = json["data"] as? String,
                                let imageData = Data(base64Encoded: b64) {
                                 await self.framesContinuation.yield(imageData)
+                            } else if type == "video_frame", let b64 = json["data"] as? String,
+                                      let imageData = Data(base64Encoded: b64) {
+                                await self.videoEventsContinuation.yield(.frame(imageData))
+                            } else if type == "video_complete", let b64 = json["data"] as? String,
+                                      let mp4Data = Data(base64Encoded: b64) {
+                                await self.videoEventsContinuation.yield(.complete(mp4Data))
+                            } else if type == "video_cancelled" {
+                                await self.videoEventsContinuation.yield(.cancelled)
                             } else if type == "status" || type == "error" {
                                 if let status = try? JSONDecoder().decode(ServerStatus.self, from: jsonData) {
                                     print("[StreamWS] Server status: \(status.status) \(status.message ?? "")")
@@ -193,5 +226,6 @@ public actor StreamWebSocketClient {
         receiveLoopTask = nil
         framesContinuation.finish()
         statusContinuation.finish()
+        videoEventsContinuation.finish()
     }
 }

--- a/ios/Packages/NetworkModule/Sources/NetworkModule/StreamWebSocketClient.swift
+++ b/ios/Packages/NetworkModule/Sources/NetworkModule/StreamWebSocketClient.swift
@@ -18,6 +18,14 @@ public actor StreamWebSocketClient {
         public let type: String
         public let status: String
         public let message: String?
+        /// Whether the pod's LTXV video pipeline loaded successfully.
+        /// Only present on `"ready"` status messages; `nil` on older pods.
+        public let videoReady: Bool?
+
+        enum CodingKeys: String, CodingKey {
+            case type, status, message
+            case videoReady = "video_ready"
+        }
     }
 
     /// Video-generation messages from the pod. Emitted only while the pod is

--- a/ios/Packages/ResultModule/Sources/ResultModule/ResultState.swift
+++ b/ios/Packages/ResultModule/Sources/ResultModule/ResultState.swift
@@ -44,6 +44,14 @@ public enum ResultState {
     case preview(image: UIImage)
     case streaming(image: UIImage, frameCount: Int = 0)
     case error(message: String, previousImage: UIImage?)
+    /// LTXV video generation in progress — pod is streaming decoded frames.
+    /// `latestFrame` is the most recent frame received; `baseImage` is the
+    /// original still that the video is being animated from (preserved so
+    /// the right pane stays visually continuous if generation aborts).
+    case videoStreaming(baseImage: UIImage, latestFrame: UIImage, framesReceived: Int)
+    /// Final MP4 has arrived and is looping. `fallbackImage` is kept for
+    /// instant restore if the player fails or the user resumes drawing.
+    case videoLooping(mp4URL: URL, fallbackImage: UIImage)
 
     public var isPreview: Bool {
         if case .preview = self { return true }

--- a/ios/Packages/ResultModule/Sources/ResultModule/ResultView.swift
+++ b/ios/Packages/ResultModule/Sources/ResultModule/ResultView.swift
@@ -1,3 +1,4 @@
+import AVFoundation
 import SwiftUI
 
 /// Displays the generated image result with support for loading, error, and empty states.
@@ -59,6 +60,12 @@ public struct ResultView: View {
 
             case .error(let message, let previousImage):
                 errorView(message: message, previousImage: previousImage)
+
+            case .videoStreaming(_, let latestFrame, let framesReceived):
+                videoStreamingView(latestFrame, framesReceived: framesReceived)
+
+            case .videoLooping(let url, let fallbackImage):
+                videoLoopingView(url: url, fallbackImage: fallbackImage)
             }
 
             if showToast {
@@ -223,6 +230,25 @@ public struct ResultView: View {
                 .background(.red.opacity(0.85), in: Capsule())
                 .padding(12)
         }
+    }
+
+    private func videoStreamingView(_ image: UIImage, framesReceived: Int) -> some View {
+        ZStack(alignment: .topTrailing) {
+            imageView(image)
+
+            Text("ANIMATING \(framesReceived)")
+                .font(.caption2.weight(.bold).monospacedDigit())
+                .foregroundStyle(.white)
+                .padding(.horizontal, 8)
+                .padding(.vertical, 4)
+                .background(.purple.opacity(0.85), in: Capsule())
+                .padding(12)
+        }
+    }
+
+    private func videoLoopingView(url: URL, fallbackImage: UIImage) -> some View {
+        LoopingVideoView(url: url, fallback: fallbackImage)
+            .shadow(color: .black.opacity(0.25), radius: 12, x: 0, y: 6)
     }
 
     private func imageView(_ image: UIImage) -> some View {
@@ -410,6 +436,70 @@ public struct ResultView: View {
         withAnimation {
             showToast = false
         }
+    }
+}
+
+// MARK: - Looping Video
+
+/// Plays an MP4 on repeat using `AVQueuePlayer` + `AVPlayerLooper`.
+/// Falls back to showing the still image if the player can't start.
+private struct LoopingVideoView: UIViewRepresentable {
+    let url: URL
+    let fallback: UIImage
+
+    func makeUIView(context: Context) -> LoopingVideoUIView {
+        LoopingVideoUIView(url: url, fallback: fallback)
+    }
+
+    func updateUIView(_ uiView: LoopingVideoUIView, context: Context) {
+        uiView.update(url: url, fallback: fallback)
+    }
+}
+
+private final class LoopingVideoUIView: UIView {
+    private var player: AVQueuePlayer?
+    private var looper: AVPlayerLooper?
+    private var playerLayer: AVPlayerLayer?
+    private let fallbackImageView = UIImageView()
+    private var currentURL: URL?
+
+    init(url: URL, fallback: UIImage) {
+        super.init(frame: .zero)
+        fallbackImageView.contentMode = .scaleAspectFit
+        addSubview(fallbackImageView)
+        update(url: url, fallback: fallback)
+    }
+
+    required init?(coder: NSCoder) { fatalError("init(coder:) not implemented") }
+
+    func update(url: URL, fallback: UIImage) {
+        fallbackImageView.image = fallback
+        if currentURL == url { return }
+        currentURL = url
+
+        playerLayer?.removeFromSuperlayer()
+        looper = nil
+        player?.pause()
+
+        let item = AVPlayerItem(url: url)
+        let queue = AVQueuePlayer(playerItem: item)
+        queue.isMuted = true
+        let loop = AVPlayerLooper(player: queue, templateItem: item)
+        let layer = AVPlayerLayer(player: queue)
+        layer.videoGravity = .resizeAspect
+        layer.frame = bounds
+        self.layer.addSublayer(layer)
+        queue.play()
+
+        player = queue
+        looper = loop
+        playerLayer = layer
+    }
+
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        fallbackImageView.frame = bounds
+        playerLayer?.frame = bounds
     }
 }
 

--- a/ios/Packages/ResultModule/Sources/ResultModule/ResultView.swift
+++ b/ios/Packages/ResultModule/Sources/ResultModule/ResultView.swift
@@ -472,6 +472,11 @@ private final class LoopingVideoUIView: UIView {
 
     required init?(coder: NSCoder) { fatalError("init(coder:) not implemented") }
 
+    deinit {
+        player?.pause()
+        playerLayer?.removeFromSuperlayer()
+    }
+
     func update(url: URL, fallback: UIImage) {
         fallbackImageView.image = fallback
         if currentURL == url { return }


### PR DESCRIPTION
When the user stops drawing, the pod's input-frame buffer goes quiet and
the same GPU that was running FLUX img2img switches to LTXV 2B distilled
image-to-video, using the most recent generated image as the first-frame
keyframe. Decoded frames stream back as text JSON messages; once all
frames are ready the pod encodes an MP4 and sends it as a final blob for
smooth AVPlayerLooper playback on the right pane. Any new sketch frame
arriving mid-generation aborts via a threading.Event checked in the
diffusers callback_on_step_end.

Client also gains a dirty check: the capture loop reuses the existing
`strokeCount` on SketchSnapshot/MetalCanvasView and skips send if the
canvas hasn't changed since the last successful frame. Config changes
clear the counter so the sketch re-renders under the new prompt.

Pod:
- video_pipeline.py loads LTXV 2B distilled (BF16, ~4 GB) at startup
  alongside FLUX on the 5090; shared threading.Lock serializes the
  two so they can't contend on the same CUDA stream
- server.py gains a `video_loop` coroutine that polls for
  (no input frame) AND (has a last-generated still) AND (no video
  already generated for it) and kicks off generation; frames are
  sent as {type: video_frame, data: base64}, MP4 as video_complete,
  cancellation as video_cancelled
- Dockerfile installs ffmpeg for the MP4 encode subprocess
- populate-volume.ts also downloads the LTXV repo to the network volume

iOS:
- StreamSession skips frames whose strokeCount matches the last send
- StreamWebSocketClient parses three new JSON message types and exposes
  them on a `videoEvents: AsyncStream<VideoEvent>` property
- ResultState gains `.videoStreaming` (during generation) and
  `.videoLooping` (AVPlayerLooper on the final MP4); both preserve the
  last successful still so Constraint #2 still holds on abort
- AppCoordinator writes the MP4 to NSTemporaryDirectory, swaps state,
  and drops the file on stream teardown once the view is detached

Per user direction: idle detection lives on the pod, not the client —
no client-side debounce. Memory plan: both models resident, fail fast
if OOM in testing. Video loops once generated; regeneration only
happens after a new still is produced.