### PR TITLE
fix(canvas): align brush/eraser preview sizes with actual stamp diameter

### DIFF
--- a/ios/Kiki/Views/CanvasSidebar.swift
+++ b/ios/Kiki/Views/CanvasSidebar.swift
@@ -38,8 +38,9 @@ struct CanvasSidebar: View {
             .frame(width: 30, height: 120)
             .overlay(alignment: .trailing) {
                 if isDraggingSize {
-                    let divisor = CanvasViewModel.penCursorDivisor
-                    let displaySize = max(coordinator.toolSize / divisor, 4)
+                    // Show the configured size at rest (force=1, perp tilt) so the
+                    // preview matches the actual stamp diameter the user will get.
+                    let displaySize = max(coordinator.toolSize, 4)
                     let containerSize = max(displaySize + 16, 32)
                     Circle()
                         .stroke(.primary, lineWidth: 1)

--- a/ios/Packages/CanvasModule/Sources/CanvasModule/CanvasViewModel.swift
+++ b/ios/Packages/CanvasModule/Sources/CanvasModule/CanvasViewModel.swift
@@ -17,10 +17,11 @@ public final class CanvasViewModel {
 
     // MARK: - Properties
 
-    /// Cursor divisor for approximating visual stroke size in the sidebar tooltip.
-    /// With the custom engine, pressure gamma means the visual width ≈ baseWidth * 0.5 at rest,
-    /// so divisor ~2.0 gives a reasonable preview.
-    public static let penCursorDivisor: CGFloat = 2.0
+    /// Display divisor applied to slider previews. 1.0 means the preview circle
+    /// matches the actual stamp diameter (= configured baseWidth) at rest. Kept
+    /// as a single named constant so the slider preview and any future cursor
+    /// callers stay in sync.
+    public static let penCursorDivisor: CGFloat = 1.0
 
     public private(set) var canUndo = false
     public private(set) var canRedo = false
@@ -95,12 +96,23 @@ public final class CanvasViewModel {
 
     public func selectBrush(_ config: BrushConfig) {
         canvasView?.currentTool = .brush(config)
-        container?.updateCursorSize(diameter: config.baseWidth, divisor: Self.penCursorDivisor)
+        container?.updateCursorSize(
+            diameter: config.baseWidth,
+            pressureGamma: config.pressureGamma,
+            tiltSensitivity: config.tiltSensitivity
+        )
     }
 
     public func selectEraser(width: CGFloat = 5) {
         canvasView?.currentTool = .eraser(width: width)
-        container?.updateCursorSize(diameter: width, divisor: Self.penCursorDivisor)
+        // Eraser builds its internal BrushConfig with pressureGamma 0.7 and
+        // tiltSensitivity 0 (see MetalCanvasView.swift). Mirror those defaults
+        // here so the cursor tracks the actual eraser stamp diameter.
+        container?.updateCursorSize(
+            diameter: width,
+            pressureGamma: 0.7,
+            tiltSensitivity: 0.0
+        )
     }
 
     public func selectLasso() {

--- a/ios/Packages/CanvasModule/Sources/CanvasModule/RotatableCanvasContainer.swift
+++ b/ios/Packages/CanvasModule/Sources/CanvasModule/RotatableCanvasContainer.swift
@@ -29,7 +29,8 @@ public final class RotatableCanvasContainer: UIView, UIGestureRecognizerDelegate
     private static let ringFingerOffset: CGFloat = 80
     private var lassoSelectionView: LassoSelectionView?
     private var cursorBaseWidth: CGFloat = 5
-    private var cursorDivisor: CGFloat = 3.0
+    private var cursorPressureGamma: CGFloat = 0.7
+    private var cursorTiltSensitivity: CGFloat = 0.0
     private static let snapThreshold: CGFloat = 0.15 // ~8.6 degrees
     private static let minScale: CGFloat = 0.5
     private static let maxScale: CGFloat = 5.0
@@ -129,12 +130,18 @@ public final class RotatableCanvasContainer: UIView, UIGestureRecognizerDelegate
             cursorView.center = location
             cursorView.isHidden = false
 
-            // Dynamically size cursor based on pressure and tilt.
-            // PK's .pen ink scales width with force and reduces it at low tilt angles.
-            let forceFraction = 0.15 + 0.85 * gesture.normalizedForce
-            // Altitude: perpendicular (π/2) = full width, flat (0) = thinner
-            let tiltFraction = 0.3 + 0.7 * (gesture.altitudeAngle / (.pi / 2))
-            let diameter = cursorBaseWidth * forceFraction * tiltFraction / cursorDivisor
+            // Match BrushConfig.effectiveWidth so the cursor reflects the actual
+            // stamp diameter (in view points) — pow(force, gamma) for pressure,
+            // and the same tiltFactor formula (which is 1.0 unless tiltSensitivity > 0).
+            let force = max(gesture.normalizedForce, 0.01)
+            let pressureFactor = pow(force, cursorPressureGamma)
+            let tiltFactor: CGFloat
+            if cursorTiltSensitivity > 0 {
+                tiltFactor = 1.0 + cursorTiltSensitivity * (1.0 - gesture.altitudeAngle / (.pi / 2)) * 2.0
+            } else {
+                tiltFactor = 1.0
+            }
+            let diameter = cursorBaseWidth * pressureFactor * tiltFactor
             cursorView.bounds = CGRect(x: 0, y: 0, width: diameter, height: diameter)
             cursorView.setNeedsDisplay()
         case .ended, .cancelled:
@@ -350,9 +357,10 @@ public final class RotatableCanvasContainer: UIView, UIGestureRecognizerDelegate
         backgroundImageView.image
     }
 
-    public func updateCursorSize(diameter: CGFloat, divisor: CGFloat = 3.0) {
+    public func updateCursorSize(diameter: CGFloat, pressureGamma: CGFloat = 0.7, tiltSensitivity: CGFloat = 0.0) {
         cursorBaseWidth = diameter
-        cursorDivisor = divisor
+        cursorPressureGamma = pressureGamma
+        cursorTiltSensitivity = tiltSensitivity
     }
 
     // MARK: - Lasso Selection


### PR DESCRIPTION
## Summary

- Cursor circle and sidebar slider preview both showed ~50% of the actual stamp diameter due to a hardcoded `penCursorDivisor = 2.0` that compensated for an effect that doesn't exist.
- Cursor's force/tilt math was a separate ad-hoc formula (`0.15 + 0.85·force`, `0.3 + 0.7·altitude`) that didn't match the stamp's `pow(force, gamma) × tiltFactor`. Notably, the cursor shrank at low tilt while the actual stamp didn't.
- Fix: drop the divisor to 1.0, replace the cursor formula with the same math as `BrushConfig.effectiveWidth`, and thread the active tool's `pressureGamma`/`tiltSensitivity` through so brush and eraser cursors track their own stamps.

## Test plan

- [ ] Build Kiki for iPad Pro 13-inch (M4) simulator — succeeds
- [ ] Brush at baseWidth=30, hard press: cursor matches stroke edge-to-edge
- [ ] Brush at low pressure: cursor and stroke shrink in sync
- [ ] Eraser at width=30: cursor matches the cleared region exactly
- [ ] Flat pencil tilt with default brush: cursor no longer shrinks (matches unchanged stroke width)
- [ ] Slider drag: preview circle diameter equals configured size at rest

🤖 Generated with [Claude Code](https://claude.com/claude-code)