### PR TITLE
fix(canvas): allow zoom/pan/rotate across the full drawing pane

### DIFF
--- a/ios/Kiki/Views/DrawingView.swift
+++ b/ios/Kiki/Views/DrawingView.swift
@@ -49,10 +49,17 @@ struct DrawingView: View {
                     geometry.size.width * coordinator.dividerPosition,
                     geometry.size.height
                 )
+                // The gesture container fills the full drawing pane so pan/zoom/
+                // rotate aren't clipped by the drawing surface's square footprint.
+                // The drawing surface itself stays a centered `canvasSide` square
+                // inside the container (see RotatableCanvasContainer).
+                let canvasPaneWidth = coordinator.drawingLayout == .splitScreen
+                    ? geometry.size.width * coordinator.dividerPosition
+                    : geometry.size.width
 
                 ZStack(alignment: .topLeading) {
-                    CanvasView(viewModel: coordinator.canvasViewModel)
-                        .frame(width: canvasSide, height: canvasSide)
+                    CanvasView(viewModel: coordinator.canvasViewModel, drawingSurfaceSide: canvasSide)
+                        .frame(width: canvasPaneWidth, height: geometry.size.height)
                         .frame(
                             maxWidth: .infinity,
                             maxHeight: .infinity,

--- a/ios/Packages/CanvasModule/Sources/CanvasModule/CanvasView.swift
+++ b/ios/Packages/CanvasModule/Sources/CanvasModule/CanvasView.swift
@@ -2,13 +2,16 @@ import SwiftUI
 
 public struct CanvasView: UIViewRepresentable {
     private let viewModel: CanvasViewModel
+    private let drawingSurfaceSide: CGFloat
 
-    public init(viewModel: CanvasViewModel) {
+    public init(viewModel: CanvasViewModel, drawingSurfaceSide: CGFloat = 0) {
         self.viewModel = viewModel
+        self.drawingSurfaceSide = drawingSurfaceSide
     }
 
     public func makeUIView(context: Context) -> RotatableCanvasContainer {
         let container = RotatableCanvasContainer()
+        container.drawingSurfaceSide = drawingSurfaceSide
         let canvasView = container.canvasView
         viewModel.attach(canvasView, container: container)
 
@@ -54,5 +57,7 @@ public struct CanvasView: UIViewRepresentable {
         return container
     }
 
-    public func updateUIView(_ uiView: RotatableCanvasContainer, context: Context) {}
+    public func updateUIView(_ uiView: RotatableCanvasContainer, context: Context) {
+        uiView.drawingSurfaceSide = drawingSurfaceSide
+    }
 }

--- a/ios/Packages/CanvasModule/Sources/CanvasModule/RotatableCanvasContainer.swift
+++ b/ios/Packages/CanvasModule/Sources/CanvasModule/RotatableCanvasContainer.swift
@@ -8,6 +8,14 @@ public final class RotatableCanvasContainer: UIView, UIGestureRecognizerDelegate
     public private(set) var rotation: CGFloat = 0
     public private(set) var scale: CGFloat = 1.0
     public private(set) var translation: CGPoint = .zero
+
+    /// Side length of the square drawing surface (in points). The container can
+    /// be wider/taller than this to host gestures over the full pane while the
+    /// actual drawing area stays a centered square of this size. 0 means fill
+    /// the container (legacy behavior).
+    public var drawingSurfaceSide: CGFloat = 0 {
+        didSet { setNeedsLayout() }
+    }
     public var onTransformChanged: (() -> Void)?
     public var onInteractionChanged: ((Bool) -> Void)?
     public var onUndoRequested: (() -> Void)?
@@ -53,10 +61,11 @@ public final class RotatableCanvasContainer: UIView, UIGestureRecognizerDelegate
         clipsToBounds = true
         backgroundColor = .black
 
-        // transformView fills container — use autoresizing so it tracks size
-        // changes without Auto Layout fighting the transform.
+        // transformView is sized in layoutSubviews — either filling the
+        // container (when drawingSurfaceSide == 0) or held as a centered
+        // square of drawingSurfaceSide. We don't use autoresizing so the
+        // transformView's frame isn't fought by the container's resize.
         transformView.frame = bounds
-        transformView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
         addSubview(transformView)
 
         // backgroundImageView sits below canvasView — always present, white bg by default.
@@ -121,6 +130,28 @@ public final class RotatableCanvasContainer: UIView, UIGestureRecognizerDelegate
         addGestureRecognizer(longPress)
     }
 
+    // MARK: - Layout
+
+    public override func layoutSubviews() {
+        super.layoutSubviews()
+
+        let side: CGFloat
+        if drawingSurfaceSide > 0 {
+            side = drawingSurfaceSide
+        } else {
+            side = min(bounds.width, bounds.height)
+        }
+
+        // Preserve any active transform so panning/zooming isn't reset by a
+        // relayout. The square is laid out centered in the container; the user
+        // can pan it anywhere within the container via gestures.
+        let previousTransform = transformView.transform
+        transformView.transform = .identity
+        transformView.bounds = CGRect(x: 0, y: 0, width: side, height: side)
+        transformView.center = CGPoint(x: bounds.midX, y: bounds.midY)
+        transformView.transform = previousTransform
+    }
+
     // MARK: - Gesture Handling
 
     @objc private func handleTouchTracking(_ gesture: TouchTrackingGestureRecognizer) {
@@ -128,7 +159,10 @@ public final class RotatableCanvasContainer: UIView, UIGestureRecognizerDelegate
         case .began, .changed:
             let location = gesture.location(in: canvasView)
             cursorView.center = location
-            cursorView.isHidden = false
+            // When the container is larger than the drawing surface, the touch
+            // can land outside canvasView's bounds — hide the cursor there so
+            // we don't draw a ring over the empty margin around the canvas.
+            cursorView.isHidden = !canvasView.bounds.contains(location)
 
             // Match BrushConfig.effectiveWidth so the cursor reflects the actual
             // stamp diameter (in view points) — pow(force, gamma) for pressure,


### PR DESCRIPTION
## Summary

The canvas container was sized to the drawing surface's square with \`clipsToBounds = true\`, so pan/zoom/rotate gestures were bounded by that square and couldn't reach the empty vertical margin or the right pane's corners. Decouple the gesture container from the drawing surface:

- \`RotatableCanvasContainer\` gets a \`drawingSurfaceSide\` property; \`layoutSubviews\` lays out the inner \`transformView\` (Metal canvas + background) as a centered square of that size and preserves any active transform across relayouts.
- \`CanvasView\` forwards the parameter.
- \`DrawingView\` sizes the canvas pane to the full right half in split-screen (or full screen in fullscreen) while still passing the \`canvasSide\` square as the drawing surface.
- Cursor overlay hides when the touch lands in the margin (outside the drawing surface bounds) so we don't draw a ring over empty space.

Drawing strokes remain bounds-gated by MetalCanvasView's own touch handling, so touches in the margin don't produce off-canvas stamps.

## Test plan

- [ ] Split-screen: two-finger pan vertically — canvas moves into the empty space above/below, no longer clipped at the square's top/bottom
- [ ] Split-screen: pinch-zoom to 5x then rotate 45° — corners of the rotated canvas reach into areas previously clipped
- [ ] Split-screen: initial position unchanged (canvas sits where it did before opening the PR)
- [ ] Fullscreen: same panning/rotating freedom, initial square stays centered
- [ ] Cursor ring does not appear when touching the empty margin around the drawing surface
- [ ] Drawing strokes don't fire when touching outside the drawing surface

🤖 Generated with [Claude Code](https://claude.com/claude-code)