### PR TITLE
Drawing toolbar redesign: settings panel + stream status in result pane

### DIFF
--- a/ios/Kiki/Views/DrawingTopBar.swift
+++ b/ios/Kiki/Views/DrawingTopBar.swift
@@ -3,13 +3,26 @@ import CanvasModule
 
 struct DrawingTopBar: View {
     @Environment(AppCoordinator.self) private var coordinator
-    @State private var showAdvancedParameters = false
+    @State private var showSettings = false
 
     var body: some View {
         @Bindable var coordinator = coordinator
 
         HStack(spacing: 12) {
-            // MARK: Left — Gallery
+            // MARK: Left — Settings, Gallery
+            Button {
+                showSettings = true
+            } label: {
+                Image(systemName: "gearshape")
+                    .font(.system(size: 18, weight: .medium))
+                    .foregroundStyle(.primary)
+                    .frame(width: 36, height: 36)
+            }
+            .popover(isPresented: $showSettings) {
+                SettingsPanel()
+                    .frame(width: 400, height: 600)
+            }
+
             Button {
                 coordinator.navigateToGallery()
             } label: {
@@ -19,7 +32,7 @@ struct DrawingTopBar: View {
 
             Spacer()
 
-            // MARK: Center — Style, Prompt, Stream Status, Settings
+            // MARK: Center — Style, Prompt
             if coordinator.drawingLayout != .splitScreen {
                 Button {
                     coordinator.showStylePicker = true
@@ -36,32 +49,6 @@ struct DrawingTopBar: View {
                     .textFieldStyle(.plain)
                     .font(.subheadline)
                     .frame(minWidth: 120, maxWidth: 400)
-            }
-
-            connectionStatusIndicator
-
-            Button {
-                showAdvancedParameters = true
-            } label: {
-                Image(systemName: "slider.horizontal.3")
-                    .font(.system(size: 18, weight: .medium))
-                    .foregroundStyle(.primary)
-                    .frame(width: 36, height: 36)
-            }
-            .popover(isPresented: $showAdvancedParameters) {
-                AdvancedParametersPanel()
-                    .frame(width: 400, height: 600)
-            }
-
-            Button {
-                coordinator.drawingLayout = coordinator.drawingLayout == .splitScreen
-                    ? .fullscreen : .splitScreen
-            } label: {
-                Image(systemName: coordinator.drawingLayout == .splitScreen
-                    ? "rectangle.inset.filled" : "rectangle.split.2x1")
-                    .font(.system(size: 18, weight: .medium))
-                    .foregroundStyle(.primary)
-                    .frame(width: 36, height: 36)
             }
 
             Spacer()
@@ -106,39 +93,6 @@ struct DrawingTopBar: View {
         .padding(.horizontal, 16)
         .padding(.vertical, 8)
         .background(.bar)
-    }
-
-    // MARK: - Connection Status
-
-    private var connectionStatusIndicator: some View {
-        HStack(spacing: 6) {
-            Circle()
-                .fill(streamStatusColor)
-                .frame(width: 8, height: 8)
-            Text(streamStatusLabel)
-                .font(.subheadline.weight(.medium))
-        }
-        .foregroundStyle(.secondary)
-        .padding(.horizontal, 14)
-        .padding(.vertical, 8)
-    }
-
-    private var streamStatusColor: Color {
-        switch coordinator.streamReadiness {
-        case .ready: return .green
-        case .warming: return .orange
-        case .disconnected: return .gray
-        case .failed: return .red
-        }
-    }
-
-    private var streamStatusLabel: String {
-        switch coordinator.streamReadiness {
-        case .ready: return "Streaming"
-        case .warming(let message, _): return message
-        case .disconnected: return "Disconnected"
-        case .failed: return "Error"
-        }
     }
 
     // MARK: - Helpers

--- a/ios/Kiki/Views/DrawingView.swift
+++ b/ios/Kiki/Views/DrawingView.swift
@@ -109,6 +109,10 @@ struct DrawingView: View {
                                 coordinator.canvasOnTop = false
                             }
                         )
+                        .overlay(alignment: .bottomLeading) {
+                            connectionStatusIndicator
+                                .padding(8)
+                        }
                         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topTrailing)
                         .padding(16)
                         .zIndex(coordinator.canvasOnTop ? 0 : 2)
@@ -155,10 +159,14 @@ struct DrawingView: View {
                     .padding(.top, 8)
                     .padding(.horizontal, 24)
             }
-            .overlay(alignment: .bottom) {
+            .overlay(alignment: .bottomLeading) {
+                connectionStatusIndicator
+                    .padding(12)
+            }
+            .overlay(alignment: .bottomTrailing) {
                 if coordinator.canSwapStreamImageToCanvas {
                     streamSwapBar
-                        .padding(.bottom, 16)
+                        .padding(12)
                 }
             }
 
@@ -175,19 +183,47 @@ struct DrawingView: View {
 
     // MARK: - Private
 
+    private var connectionStatusIndicator: some View {
+        HStack(spacing: 6) {
+            Circle()
+                .fill(streamStatusColor)
+                .frame(width: 7, height: 7)
+            Text(streamStatusLabel)
+                .font(.caption.weight(.medium))
+        }
+        .foregroundStyle(.secondary)
+        .padding(.horizontal, 10)
+        .padding(.vertical, 5)
+        .background(.ultraThinMaterial, in: Capsule())
+    }
+
+    private var streamStatusColor: Color {
+        switch coordinator.streamReadiness {
+        case .ready: return .green
+        case .warming: return .orange
+        case .disconnected: return .gray
+        case .failed: return .red
+        }
+    }
+
+    private var streamStatusLabel: String {
+        switch coordinator.streamReadiness {
+        case .ready: return "Streaming · frame \(coordinator.streamFrameCount)"
+        case .warming(let message, _): return message
+        case .disconnected: return "Disconnected"
+        case .failed: return "Error"
+        }
+    }
+
     private var streamSwapBar: some View {
         Button {
             coordinator.swapStreamImageToCanvas()
         } label: {
-            Label("Send to Canvas", systemImage: "arrow.left.arrow.right")
+            Label("Send to Canvas", systemImage: "arrow.right")
                 .font(.caption)
         }
         .buttonStyle(.borderedProminent)
         .controlSize(.small)
-        .padding(.horizontal, 16)
-        .padding(.vertical, 10)
-        .background(.ultraThinMaterial, in: Capsule())
-        .shadow(color: .black.opacity(0.15), radius: 8, y: 4)
     }
 }
 

--- a/ios/Kiki/Views/RootView.swift
+++ b/ios/Kiki/Views/RootView.swift
@@ -15,6 +15,7 @@ struct RootView: View {
                 DrawingView()
             }
         }
+        .statusBarHidden(true)
         .animation(.easeInOut(duration: 0.25), value: coordinator.currentScreen)
         .onAppear {
             // didSet on AppCoordinator.currentScreen handles subsequent

--- a/ios/Kiki/Views/SettingsPanel.swift
+++ b/ios/Kiki/Views/SettingsPanel.swift
@@ -1,7 +1,7 @@
 import SwiftUI
 import SwiftData
 
-struct AdvancedParametersPanel: View {
+struct SettingsPanel: View {
     @Environment(AppCoordinator.self) private var coordinator
 
     var body: some View {
@@ -9,6 +9,7 @@ struct AdvancedParametersPanel: View {
 
         NavigationStack {
             Form {
+                displaySection
                 streamParametersSection
                 captureSection
 
@@ -17,15 +18,28 @@ struct AdvancedParametersPanel: View {
                         coordinator.streamSteps = 4
                         coordinator.streamSeed = nil
                         coordinator.streamCaptureFPS = 2
+                        coordinator.drawingLayout = .splitScreen
                     }
                 }
             }
-            .navigationTitle("Advanced")
+            .navigationTitle("Settings")
             .navigationBarTitleDisplayMode(.inline)
         }
     }
 
     // MARK: - Sections
+
+    private var displaySection: some View {
+        @Bindable var coordinator = coordinator
+
+        return Section("Display") {
+            Picker("Layout", selection: $coordinator.drawingLayout) {
+                Text("Split").tag(DrawingLayout.splitScreen)
+                Text("Fullscreen").tag(DrawingLayout.fullscreen)
+            }
+            .pickerStyle(.segmented)
+        }
+    }
 
     private var streamParametersSection: some View {
         @Bindable var coordinator = coordinator
@@ -92,7 +106,7 @@ struct AdvancedParametersPanel: View {
 }
 
 #Preview {
-    AdvancedParametersPanel()
+    SettingsPanel()
         .environment(AppCoordinator(modelContext: try! ModelContainer(for: Drawing.self).mainContext))
         .frame(width: 400, height: 600)
 }

--- a/ios/Packages/ResultModule/Sources/ResultModule/ResultView.swift
+++ b/ios/Packages/ResultModule/Sources/ResultModule/ResultView.swift
@@ -213,17 +213,7 @@ public struct ResultView: View {
     }
 
     private func streamingView(_ image: UIImage, frameCount: Int) -> some View {
-        ZStack(alignment: .topTrailing) {
-            imageView(image)
-
-            Text("LIVE \(frameCount)")
-                .font(.caption2.weight(.bold).monospacedDigit())
-                .foregroundStyle(.white)
-                .padding(.horizontal, 8)
-                .padding(.vertical, 4)
-                .background(.red.opacity(0.85), in: Capsule())
-                .padding(12)
-        }
+        imageView(image)
     }
 
     private func imageView(_ image: UIImage) -> some View {


### PR DESCRIPTION
## Summary
- Toolbar gets a single gear button (left of Gallery) that opens `SettingsPanel`. The panel absorbs both the old Advanced Parameters and the standalone Split/Fullscreen layout toggle.
- Streaming status indicator moves from the toolbar to the bottom-leading corner of the result pane (split-screen + floating panel), with the frame count appended (replaces the red LIVE badge that used to live in the result pane's top-right).
- Send-to-Canvas button: stripped of its capsule/shadow wrapper, right-aligned inside the result pane (closer to the canvas), and the exchange-arrow icon swapped for a single right arrow.
- iOS status bar (time/battery/wifi) hidden app-wide via `RootView`.

## Test plan
- [ ] Tap the gear button -> Settings popover opens; Display picker switches between Split and Fullscreen and persists across launches
- [ ] Streaming indicator at bottom-left of result pane shows current state and frame count while streaming
- [ ] Old red LIVE badge in result pane is gone
- [ ] Send-to-Canvas button appears bottom-right of result pane (when applicable), no wrapper background, right-arrow icon
- [ ] iOS status bar is hidden in sign-in, gallery, and drawing screens