### PR TITLE
fix(ui): remove @FocusState on prompt text field to kill ~1s tap delay

### DIFF
--- a/ios/Kiki/Views/DrawingView.swift
+++ b/ios/Kiki/Views/DrawingView.swift
@@ -229,7 +229,11 @@ struct DrawingView: View {
 
 private struct PromptTitleBar: View {
     @Environment(AppCoordinator.self) private var coordinator
-    @FocusState private var isFocused: Bool
+    // Plain @State rather than @FocusState — the latter causes SwiftUI to
+    // auto-generate an InputAccessoryGenerator view for prev/next keyboard
+    // navigation, which (on iPad) triggers a constraint conflict with the
+    // SystemInputAssistantView and adds ~1s to TextField tap latency.
+    @State private var isFocused: Bool = false
 
     var body: some View {
         @Bindable var coordinator = coordinator
@@ -247,20 +251,23 @@ private struct PromptTitleBar: View {
                     .foregroundStyle(Color.accentColor)
             }
 
-            TextField("Describe your image…", text: $coordinator.promptText)
-                .textFieldStyle(.plain)
-                .font(.title3.weight(.medium))
-                .multilineTextAlignment(.center)
-                .focused($isFocused)
-                .padding(.horizontal, 14)
-                .padding(.vertical, 8)
-                .overlay(alignment: .bottom) {
-                    Rectangle()
-                        .fill(isFocused ? Color.accentColor : Color.secondary.opacity(0.35))
-                        .frame(height: isFocused ? 1.5 : 1)
-                        .animation(.easeInOut(duration: 0.15), value: isFocused)
-                }
-                .frame(maxWidth: 520)
+            TextField(
+                "Describe your image…",
+                text: $coordinator.promptText,
+                onEditingChanged: { editing in isFocused = editing }
+            )
+            .textFieldStyle(.plain)
+            .font(.title3.weight(.medium))
+            .multilineTextAlignment(.center)
+            .padding(.horizontal, 14)
+            .padding(.vertical, 8)
+            .overlay(alignment: .bottom) {
+                Rectangle()
+                    .fill(isFocused ? Color.accentColor : Color.secondary.opacity(0.35))
+                    .frame(height: isFocused ? 1.5 : 1)
+                    .animation(.easeInOut(duration: 0.15), value: isFocused)
+            }
+            .frame(maxWidth: 520)
         }
     }
 }


### PR DESCRIPTION
## Summary

Tapping the prompt TextField in split-screen had a ~1s delay, sometimes swallowed taps entirely, and spammed two \`UIViewAlertForUnsatisfiableConstraints\` warnings on every keyboard presentation.

Root cause: \`@FocusState\` + \`.focused()\` on a TextField makes SwiftUI auto-generate an \`InputAccessoryGenerator.RootUIView\` and attach it as the keyboard's input accessory view. On iPad that fights the \`SystemInputAssistantView\` layout constraints and adds significant latency to tap-to-focus. Only \`PromptTitleBar\` used \`@FocusState\` (just to drive the focus-colored underline), which is why \`DrawingTopBar\`'s TextField didn't have the delay.

Swap \`@FocusState\` for a plain \`@State Bool\` driven by \`TextField(..., onEditingChanged:)\`. Same underline animation, no auto-generated accessory view, no constraint conflict, no delay.

## Test plan

- [ ] Tap prompt TextField in split-screen → focuses instantly (~keyboard animation only, no full-second pause)
- [ ] Underline animates to accent color on focus and back on resign
- [ ] Constraint-warning spam for \`SwiftUI.InputAccessoryGenerator\` stops
- [ ] DrawingTopBar prompt TextField (fullscreen layout) still behaves correctly
- [ ] Result-image eyedropper long-press still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)