### PR TITLE
refactor(state): add 'connecting' state for pod-ready → relay-ready gap

### DIFF
--- a/backend/src/modules/auth/rateLimiter.ts
+++ b/backend/src/modules/auth/rateLimiter.ts
@@ -33,7 +33,7 @@ const HISTORY_PREFIX = 'ratelimit:provisions:';
 // reconnect). Mirrors the `State` enum in orchestrator.ts; duplicated here to
 // avoid pulling the orchestrator's module graph into the auth layer.
 const ACTIVE_STATES = new Set([
-  'queued', 'finding_gpu', 'creating_pod', 'fetching_image', 'warming_model', 'ready',
+  'queued', 'finding_gpu', 'creating_pod', 'fetching_image', 'warming_model', 'connecting', 'ready',
 ]);
 
 function historyKey(userId: string): string {

--- a/backend/src/modules/orchestrator/orchestrator.ts
+++ b/backend/src/modules/orchestrator/orchestrator.ts
@@ -138,12 +138,13 @@ export type State =
   | 'creating_pod'    // createSpotPod / createOnDemandPod RPC
   | 'fetching_image'  // pod exists; waiting for pod.runtime (GHCR image pull)
   | 'warming_model'   // container running; polling /health while model loads
-  | 'ready'           // pod serving traffic
+  | 'connecting'      // pod /health ok; backend wiring the iOS↔pod frame relay
+  | 'ready'           // relay live; iOS can stream
   | 'failed'          // unrecoverable error; WS closes after
   | 'terminated';     // session ended (reaped / aborted / replaced out)
 
 const ACTIVE_PROVISION_STATES: readonly State[] = [
-  'queued', 'finding_gpu', 'creating_pod', 'fetching_image', 'warming_model',
+  'queued', 'finding_gpu', 'creating_pod', 'fetching_image', 'warming_model', 'connecting',
 ] as const;
 
 export function isActiveProvisioning(state: State): boolean {
@@ -335,8 +336,11 @@ export async function subscribe(
 
 /**
  * Write a state transition to Redis and fan out to every subscriber.
+ * Exported so stream.ts can emit `connecting` / `ready` after the frame
+ * relay is wired up (those emits can't happen inside provision() because
+ * provision doesn't own the relay).
  */
-async function emitState(
+export async function emitState(
   sessionId: string,
   state: State,
   failureCategory: FailureCategory | null = null,
@@ -1008,18 +1012,18 @@ async function provision(sessionId: string): Promise<ProvisionResult> {
 
             const totalMs = Date.now() - t0;
 
-            // 5. Build WebSocket URL, persist pod info, transition to ready.
+            // 5. Pod is serving. Persist pod info and return — stream.ts will
+            // emit 'connecting' / 'ready' once it wires up the iOS↔pod relay.
+            // Keeping the 'ready' emit out of provision() prevents a window
+            // where iOS sees 'ready' but the backend's relay isn't yet set up
+            // to forward its frames to the pod.
             const podUrl = `wss://${podId}-8766.proxy.runpod.net/ws`;
-            // Persist pod info first so the 'ready' emit's readSession picks it up
-            // for the broker fan-out.
             await patchSession(sessionId, { podId, podUrl, podType });
-            await emitState(sessionId, 'ready');
-            currentState = 'ready';
             log.info(
               { sessionId, podId, podUrl, podType, totalMs, attempt, dc },
-              'Pod ready',
+              'Pod serving — awaiting relay',
             );
-            notifyPodProgress(podId, `✅ **Pod ready** (${Math.round(totalMs / 1000)}s total)`);
+            notifyPodProgress(podId, `✅ **Pod serving** (${Math.round(totalMs / 1000)}s total)`);
 
             parentSpan.setAttributes({
               dc: dc ?? 'unknown',

--- a/backend/src/routes/stream.ts
+++ b/backend/src/routes/stream.ts
@@ -12,6 +12,7 @@ import {
   touch,
   sessionClosed,
   subscribe,
+  emitState,
 } from '../modules/orchestrator/orchestrator.js';
 import { StreamRelay } from '../modules/relay/streamRelay.js';
 import {
@@ -165,6 +166,9 @@ export const streamRoute: FastifyPluginAsync = async (fastify) => {
           return;
         }
 
+        // Pod is serving; transition to 'connecting' while we wire up the relay.
+        await emitState(userId, 'connecting');
+
         relay = new StreamRelay(podUrl);
 
         relay.onMessage((data, isBinary) => {
@@ -218,6 +222,7 @@ export const streamRoute: FastifyPluginAsync = async (fastify) => {
               // existing broker subscription forwards them to iOS with
               // replacementCount > 0 so the UI prefixes "Replacing — ".
               const { podUrl: newPodUrl } = await replaceSession(userId);
+              await emitState(userId, 'connecting');
 
               // If client left during replacement, clean up the new pod
               if (clientDisconnected || socket.readyState !== socket.OPEN) {
@@ -259,11 +264,12 @@ export const streamRoute: FastifyPluginAsync = async (fastify) => {
               request.log.info({ userId, newPodUrl }, 'Replacement relay connected');
 
               // Re-send config so the new pod knows prompt/style/params.
-              // Note: state='ready' was already emitted via the broker when
-              // provision() completed; iOS has seen it.
               if (lastConfig) {
                 newRelay.sendConfig(lastConfig);
               }
+
+              // Replacement relay live — iOS can stream again.
+              await emitState(userId, 'ready');
             } catch (err) {
               request.log.error({ userId, err }, 'Replacement failed');
               if (socket.readyState === socket.OPEN) {
@@ -282,8 +288,6 @@ export const streamRoute: FastifyPluginAsync = async (fastify) => {
 
         await relay.connect();
         request.log.info({ userId }, 'Upstream connected, relaying');
-        // state='ready' was already emitted via the broker when provision()
-        // completed; iOS has seen it.
 
         socket.on('message', (data: Buffer | ArrayBuffer | Buffer[], isBinary: boolean) => {
           if (!relay) return;
@@ -304,6 +308,10 @@ export const streamRoute: FastifyPluginAsync = async (fastify) => {
             }
           }
         });
+
+        // Relay connected AND message handler registered — iOS frames will
+        // now flow to the pod. Safe to tell iOS we're truly ready.
+        await emitState(userId, 'ready');
       } catch (err) {
         request.log.error({ userId, err }, 'Provisioning or relay failed');
         // If the failure happened essentially-instantly, getOrProvisionPod

--- a/ios/Kiki/App/ProvisionState.swift
+++ b/ios/Kiki/App/ProvisionState.swift
@@ -10,6 +10,7 @@ public enum ProvisionState: String, Decodable, Sendable {
     case creatingPod = "creating_pod"
     case fetchingImage = "fetching_image"
     case warmingModel = "warming_model"
+    case connecting
     case ready
     case failed
     case terminated
@@ -39,6 +40,7 @@ public func displayText(for state: ProvisionState, replacementCount: Int) -> Str
     case .creatingPod:    return "\(prefix)Creating pod..."
     case .fetchingImage:  return "\(prefix)Fetching container..."
     case .warmingModel:   return "\(prefix)Warming up AI model..."
+    case .connecting:     return "\(prefix)Connecting..."
     case .ready:          return "Ready"
     case .failed:         return "Something went wrong"
     case .terminated:     return "Session ended"

--- a/ios/Kiki/App/StreamSession.swift
+++ b/ios/Kiki/App/StreamSession.swift
@@ -348,7 +348,7 @@ final class StreamSession {
         failureCategory: FailureCategory?
     ) {
         switch state {
-        case .queued, .findingGpu, .creatingPod, .fetchingImage, .warmingModel:
+        case .queued, .findingGpu, .creatingPod, .fetchingImage, .warmingModel, .connecting:
             self.warm(message: displayText(for: state, replacementCount: replacementCount))
         case .ready:
             self.setReadiness(.ready)


### PR DESCRIPTION
## Summary

Split the ambiguous \`ready\` state into two explicit milestones:

- \`warming_model\` — pod still loading the model
- **\`connecting\` (new)** — pod \`/health\` ok; backend wiring the frame relay
- \`ready\` — relay live, iOS can stream

## Why

Before: \`provision()\` emitted \`ready\` as soon as pod's \`/health\` returned ok. But stream.ts still needed to do \`relay.connect()\` (WS upgrade to pod) and register \`socket.on('message')\` before iOS frames could actually flow. During that 50ms–1s window iOS thought it was live and could send frames that got silently dropped (no handler registered).

After: \`provision()\` ends at \`warming_model\`. stream.ts emits \`connecting\` after the pod is serving, then \`ready\` only after \`relay.connect()\` succeeds AND \`socket.on('message')\` is registered. When iOS sees 'ready', frames will actually flow.

Same structure applies to the replacement flow (spot preemption): replaceSession's internal provision() leaves state at warming_model; stream.ts's onClose handler emits connecting/ready around the new-relay setup.

## What changed

- \`State\` enum: added \`'connecting'\` between \`'warming_model'\` and \`'ready'\`
- \`emitState\` exported from orchestrator so stream.ts can call it
- \`provision()\`: removed the final \`emitState(ready)\`; just persists pod info and returns
- \`stream.ts\`: emits \`connecting\` after \`getOrProvisionPod\` returns, \`ready\` after \`relay.connect()\` + \`socket.on('message')\` registration. Same for replacement path.
- \`rateLimiter.ts\`: \`connecting\` added to ACTIVE_STATES
- iOS: \`ProvisionState.connecting\` case, \`displayText\` returns \"Connecting...\" (or \"Replacing — Connecting...\" during replacement)

## Test plan

- [x] \`npm run build\` clean
- [x] \`npm test\` 17/17 pass
- [x] \`xcodebuild\` clean
- [ ] Post-deploy: fresh provision should sequence through all 6 active states ending in \"Ready\" only after the relay is live

🤖 Generated with [Claude Code](https://claude.com/claude-code)