### PR TITLE
feat(analytics): log per-state-transition events to PostHog

### DIFF
--- a/backend/src/modules/analytics/index.ts
+++ b/backend/src/modules/analytics/index.ts
@@ -60,6 +60,29 @@ export function trackPodProvisionStarted(props: {
   });
 }
 
+/**
+ * Fires on every provision-state transition (one event per state change).
+ * Lets PostHog funnels answer: "what % of users reach warming_model?",
+ * "where do users fail?", "how long between each state?". The per-event
+ * `state_entered_at` pairs with PostHog's own event timestamp for duration
+ * math; `replacement_count` distinguishes fresh provisions from preemption
+ * recoveries.
+ */
+export function trackPodStateEntered(props: {
+  userId: string;
+  state: string;
+  stateEnteredAt: number;
+  replacementCount: number;
+  failureCategory: string | null;
+}): void {
+  capture(props.userId, 'pod.state.entered', {
+    state: props.state,
+    state_entered_at: props.stateEnteredAt,
+    replacement_count: props.replacementCount,
+    ...(props.failureCategory ? { failure_category: props.failureCategory } : {}),
+  });
+}
+
 export function trackPodProvisionCompleted(props: {
   userId: string;
   durationMs: number;

--- a/backend/src/modules/orchestrator/orchestrator.ts
+++ b/backend/src/modules/orchestrator/orchestrator.ts
@@ -115,6 +115,7 @@ import {
   trackPodProvisionStalled,
   trackPodProvisionVanished,
   trackPodReplacementExhausted,
+  trackPodStateEntered,
   trackPodTerminated,
 } from '../analytics/index.js';
 
@@ -348,16 +349,34 @@ export async function emitState(
   const now = Date.now();
   await patchSession(sessionId, { state, stateEnteredAt: now, failureCategory });
   const session = await readSession(sessionId);  // pick up replacementCount
+  const replacementCount = session?.replacementCount ?? 0;
   const event: StateEvent = {
     state,
     stateEnteredAt: now,
-    replacementCount: session?.replacementCount ?? 0,
+    replacementCount,
     failureCategory,
   };
+
+  // Fan out to in-process subscribers (iOS WebSocket handlers in stream.ts).
   subscribers.get(sessionId)?.forEach((h) => {
     try { h(event); } catch (err) {
       log.warn({ sessionId, err: (err as Error).message }, 'State subscriber threw');
     }
+  });
+
+  // Sentry breadcrumb for error-trace context + PostHog event for funnel analytics.
+  Sentry.addBreadcrumb({
+    category: 'provision',
+    level: 'info',
+    message: `state → ${state}`,
+    data: { sessionId, state, replacementCount, failureCategory },
+  });
+  trackPodStateEntered({
+    userId: sessionId,
+    state,
+    stateEnteredAt: now,
+    replacementCount,
+    failureCategory,
   });
 }
 


### PR DESCRIPTION
## Summary

Every state transition now fires a \`pod.state.entered\` PostHog event (in addition to the existing summary events like \`pod.provision.started/completed/failed\`). Enables per-phase funnel analysis directly in PostHog.

## Event shape

\`\`\`
event: pod.state.entered
distinct_id: <userId>
properties:
  state: queued | finding_gpu | creating_pod | fetching_image | warming_model | connecting | ready | failed | terminated
  state_entered_at: <ms epoch>
  replacement_count: 0 (fresh) | 1+ (replacement)
  failure_category: <string>  (only when state=failed)
\`\`\`

## Queries it enables

- **Funnel**: pod.state.entered where state=queued → finding_gpu → creating_pod → fetching_image → warming_model → connecting → ready. Shows drop-off per stage.
- **Duration per state**: time between consecutive pod.state.entered events for the same user.
- **Failure distribution by state**: filter state=failed, group by the immediately preceding state.
- **Replacement behavior**: filter replacement_count > 0 to isolate preemption recoveries.

## Also added

- Sentry breadcrumb \`provision: state → X\` on every transition — error reports now carry state history leading to the error.

## Test plan

- [x] \`npm run build\` clean
- [x] \`npm test\` 17/17 pass
- [ ] After deploy, trigger a provision and confirm \`pod.state.entered\` events appear in PostHog with the expected sequence

🤖 Generated with [Claude Code](https://claude.com/claude-code)