### PR TITLE
style(canvas): tint undo/redo buttons to Color.primary

### DIFF
--- a/ios/Kiki/Views/CanvasSidebar.swift
+++ b/ios/Kiki/Views/CanvasSidebar.swift
@@ -103,6 +103,7 @@ struct CanvasSidebar: View {
                 .foregroundStyle(disabled ? .tertiary : .primary)
                 .frame(width: 36, height: 36)
         }
+        .tint(Color.primary)
         .disabled(disabled)
     }
 }


### PR DESCRIPTION
## Summary
- Match the top toolbar's monochrome treatment for the canvas sidebar's undo/redo buttons.
- Adds `.tint(Color.primary)` to override SwiftUI's default accent-color (blue) Button tint, so enabled buttons render white/black per color scheme rather than blue.

## Test plan
- [ ] Build the iOS app and open a drawing.
- [ ] Make a few strokes, confirm the undo button is white (not blue) when available.
- [ ] Undo back to start, confirm it greys out (`.tertiary`).
- [ ] Redo, confirm redo button is white when available.

🤖 Generated with [Claude Code](https://claude.com/claude-code)