### PR TITLE
feat(analytics): attach previous_state + duration to each state event

### DIFF
--- a/backend/src/modules/analytics/index.ts
+++ b/backend/src/modules/analytics/index.ts
@@ -61,23 +61,33 @@ export function trackPodProvisionStarted(props: {
 }
 
 /**
- * Fires on every provision-state transition (one event per state change).
- * Lets PostHog funnels answer: "what % of users reach warming_model?",
- * "where do users fail?", "how long between each state?". The per-event
- * `state_entered_at` pairs with PostHog's own event timestamp for duration
- * math; `replacement_count` distinguishes fresh provisions from preemption
- * recoveries.
+ * Fires on every provision-state transition. Each event carries both "I
+ * just entered state X" and "I was in state Y for N ms before that" so
+ * per-state duration analysis is a one-line HogQL query:
+ *
+ *   SELECT avg(properties.previous_state_duration_ms)
+ *   FROM events
+ *   WHERE event = 'pod.state.entered'
+ *     AND properties.previous_state = 'fetching_image'
+ *
+ * `previous_state` / `previous_state_duration_ms` are null for the first
+ * state of a provision cycle (no prior state to measure). `replacement_count`
+ * distinguishes fresh provisions from preemption recoveries.
  */
 export function trackPodStateEntered(props: {
   userId: string;
   state: string;
   stateEnteredAt: number;
+  previousState: string | null;
+  previousStateDurationMs: number | null;
   replacementCount: number;
   failureCategory: string | null;
 }): void {
   capture(props.userId, 'pod.state.entered', {
     state: props.state,
     state_entered_at: props.stateEnteredAt,
+    previous_state: props.previousState,
+    previous_state_duration_ms: props.previousStateDurationMs,
     replacement_count: props.replacementCount,
     ...(props.failureCategory ? { failure_category: props.failureCategory } : {}),
   });

--- a/backend/src/modules/orchestrator/orchestrator.ts
+++ b/backend/src/modules/orchestrator/orchestrator.ts
@@ -347,9 +347,21 @@ export async function emitState(
   failureCategory: FailureCategory | null = null,
 ): Promise<void> {
   const now = Date.now();
+
+  // Read the *current* (soon-to-be-previous) state so we can attach its
+  // duration to the outgoing PostHog event. This turns per-state duration
+  // analytics into a one-line query: AVG(previous_state_duration_ms) WHERE
+  // previous_state = 'X'. The alternative (post-hoc LEAD() in HogQL) works
+  // but costs a self-join on every dashboard.
+  const prevSession = await readSession(sessionId);
+  const previousState = prevSession?.state ?? null;
+  const previousStateDurationMs = prevSession?.stateEnteredAt
+    ? now - prevSession.stateEnteredAt
+    : null;
+  const replacementCount = prevSession?.replacementCount ?? 0;
+
   await patchSession(sessionId, { state, stateEnteredAt: now, failureCategory });
-  const session = await readSession(sessionId);  // pick up replacementCount
-  const replacementCount = session?.replacementCount ?? 0;
+
   const event: StateEvent = {
     state,
     stateEnteredAt: now,
@@ -369,12 +381,14 @@ export async function emitState(
     category: 'provision',
     level: 'info',
     message: `state → ${state}`,
-    data: { sessionId, state, replacementCount, failureCategory },
+    data: { sessionId, state, previousState, previousStateDurationMs, replacementCount, failureCategory },
   });
   trackPodStateEntered({
     userId: sessionId,
     state,
     stateEnteredAt: now,
+    previousState,
+    previousStateDurationMs,
     replacementCount,
     failureCategory,
   });


### PR DESCRIPTION
## Summary

Each \`pod.state.entered\` event now carries two additional properties: \`previous_state\` and \`previous_state_duration_ms\`. These enable per-state duration analysis via a one-line HogQL query instead of a self-join.

## What changed

- \`trackPodStateEntered\` signature + payload extended with \`previous_state\` and \`previous_state_duration_ms\`.
- \`emitState\` reads the current (soon-to-be-previous) state from Redis before patching, computes duration from \`stateEnteredAt\`, includes both in the PostHog event and the Sentry breadcrumb.
- No new events, no change in event volume.

## Example queries

**Average duration per state:**
\`\`\`
SELECT properties.previous_state, avg(properties.previous_state_duration_ms)
FROM events
WHERE event = 'pod.state.entered'
  AND properties.previous_state IS NOT NULL
GROUP BY properties.previous_state
\`\`\`

**Where do users fail:**
\`\`\`
SELECT properties.previous_state, count()
FROM events
WHERE event = 'pod.state.entered'
  AND properties.state = 'failed'
GROUP BY properties.previous_state
\`\`\`

**Timeline for user X's last provision:**
\`\`\`
SELECT timestamp, properties.state, properties.previous_state, properties.previous_state_duration_ms
FROM events
WHERE distinct_id = '<user>'
  AND event = 'pod.state.entered'
ORDER BY timestamp DESC
LIMIT 10
\`\`\`

## Test plan

- [x] \`npm run build\` clean
- [x] \`npm test\` 17/17 pass
- [ ] After deploy: trigger a provision, confirm pod.state.entered events include previous_state / previous_state_duration_ms fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)