### PR TITLE
docs: record the provision state-machine refactor decisions

### DIFF
--- a/documents/decisions.md
+++ b/documents/decisions.md
@@ -14,6 +14,25 @@ Record implementation decisions here as they are made. Newest first. This preven
 
 ---
 
+### 2026-04-23 — Structured state machine for provisioning (replaces free-form status strings)
+**Context:** Backend emitted 14 free-form status strings ("Pulling container image...", "Pod is starting up...", etc.) over the iOS WebSocket; iOS displayed them verbatim. Three problems: (1) iOS joiners reconnecting mid-provision got a one-shot "Pod is starting up..." and silence because `onStatus` was bound to the original caller's WS — joiner's callback was never wired in. (2) Display text crossed the wire, conflating state (backend's concern) with presentation (iOS's concern). (3) Redis had `SessionStatus` and the orchestrator had a separate `ProvisionPhase` type — two state machines at different granularities.
+**Decision:** Single flat `State` enum (9 values: `queued | finding_gpu | creating_pod | fetching_image | warming_model | connecting | ready | failed | terminated`). Wire format is structured: `{ type: 'state', state, stateEnteredAt, replacementCount, failureCategory? }`. Backend never emits display strings; iOS maps state codes → user-facing text locally. In-memory broker (`subscribe` + `emitState`) fans out transitions to every WS connection for the session, so fresh callers and joiners share one mechanism. Redis stays the source of truth; broker owns subscriber sets only.
+**Alternatives considered:**
+- **Merge `status` and `phase` internally but keep free-form strings on the wire** — preserves the joiner bug and the layering violation; didn't solve either root cause.
+- **Polling-based "last status" field in Redis** — simpler, but 1s latency is visible and reintroduces "display text in Redis" which the layering cleanup was trying to eliminate.
+- **Fold the `connecting` state into `warming_model`** — lose explicit visibility into a distinct phase (pod `/health` ok but relay not yet connected). This gap caused silent frame drops when iOS thought "Ready" but the backend's `socket.on('message')` handler wasn't registered yet.
+- **Don't separate `ready` from pod-ok vs relay-ready** — same silent-drop issue; "Ready" must mean iOS can actually stream, not just "pod is alive."
+- **Emit separate `pod.state.exited` events for analytics** — doubles event volume for the same information. Instead, each `pod.state.entered` event carries `previous_state` + `previous_state_duration_ms`.
+**Consequences:**
+- `replacementCount` stays incremented through a session's life (doesn't reset on successful replacement). Required for the `MAX_SESSION_REPLACEMENTS` cap to protect against flapping pods. Tradeoff: after one preemption, reconnect flows briefly flash "Replacing — ..." until the session fully retires. Acceptable at current scale.
+- `waitForReplacement` (polling helper) deleted — broker subscribers handle mid-replacement connects natively.
+- `PodVanishedError.phase` renamed to `.state`; `FailureCategory` renamed (`runtime_up_timeout` → `fetch_image_timeout`, `health_timeout` → `warm_model_timeout`) to match.
+- Rate limiter's `ACTIVE_SESSION_STATUSES` set moved to `ACTIVE_STATES` with new values — easy to forget when adding states; see `backend/src/modules/auth/rateLimiter.ts`.
+- Adding new states in the future: update (1) backend `State` union, (2) iOS `ProvisionState` enum, (3) iOS `displayText()`, (4) rate limiter `ACTIVE_STATES` if non-terminal, (5) `ACTIVE_PROVISION_STATES` in orchestrator.ts.
+- Wire protocol change: atomic swap across backend + iOS. Dev build only — single user rebuilds iOS and deploys backend in lockstep. TestFlight would require a dual-send compat layer.
+
+---
+
 ### 2026-03-25 — Gallery home page with SwiftData local persistence
 **Context:** App was single-screen with no persistence. Drawings were lost on app close. Needed a way to save, browse, and resume multiple drawings.
 **Decision:** Add a gallery home page as the app root (state-based navigation, no NavigationStack). Each drawing is a SwiftData `@Model` with `@Attribute(.externalStorage)` for all image blobs. Auto-save on change (debounced 1s for UI events, immediate after generation). CanvasViewModel uses a pending-state pattern for save/restore: `setPendingState()` queues data before navigation, `attach()` applies it before the PKCanvasView delegate is set to avoid spurious change events. Gallery uses `@Query` for automatic SwiftData observation. Empty drawings are cleaned up on gallery navigation.

--- a/documents/references/provider-config.md
+++ b/documents/references/provider-config.md
@@ -14,9 +14,9 @@ Server image: `ghcr.io/donpinkus/kiki-flux-klein:<tag>` — a slim (~2–3 GB) i
 ## How pod provisioning works
 
 1. iPad sends Apple Sign In identity token → backend issues JWT. Client opens WebSocket to `wss://kiki-backend.../v1/stream` with `Authorization: Bearer <jwt>`.
-2. Backend's `orchestrator.ts` checks its in-memory session registry keyed by `userId`:
-   - **Existing ready pod** → relay immediately.
-   - **In-flight provision** → await the existing promise, forward status messages.
+2. Backend's `orchestrator.ts` checks Redis for the session + its in-memory `inFlightProvisions` map, both keyed by `userId`:
+   - **Existing ready pod** (`state='ready'` + `podUrl`) → relay immediately.
+   - **In-flight provision** (any non-terminal state + promise in `inFlightProvisions`) → await the existing promise. The broker (`subscribe`) fans out current + future state events to all WS connections for the session, so joiners see the current phase immediately.
    - **No record** → acquire semaphore slot (cap 5 concurrent), run placement + provision flow.
 3. Placement: `selectPlacement()` probes all configured volume-DCs in parallel for 5090 spot stock, picks the DC with the best stock level.
 4. Pod creation: tries spot first in the selected DC with the network volume attached. If spot capacity is exhausted and `ONDEMAND_FALLBACK_ENABLED=true`, falls back to on-demand in the same DC.
@@ -25,14 +25,25 @@ Server image: `ghcr.io/donpinkus/kiki-flux-klein:<tag>` — a slim (~2–3 GB) i
 7. A `setInterval` reaper scans the registry every 60s and terminates pods idle >30 min.
 8. On backend restart: `reconcileOrphanPods()` lists all `kiki-session-*` pods and terminates them (prevents cost leaks from crashes).
 
-### Status messages shown to user during provision
+### Provision state machine
 
-1. "Finding available GPU..." — probing DC stock
-2. "Provisioning GPU..." — creating the pod
-3. "Pulling container image..." — waiting for container runtime (image pull)
-4. "Starting server..." — container up, transitioning to health poll
-5. "Loading AI model & warming up..." — FLUX server loading weights + warmup inference
-6. "Ready"
+Backend tracks the provision lifecycle in a single flat `State` enum (see `backend/src/modules/orchestrator/orchestrator.ts`). The wire format is structured — `{ type: 'state', state, stateEnteredAt, replacementCount, failureCategory? }` — and iOS maps state codes to display text locally (see `ios/Kiki/App/ProvisionState.swift`). Backend never emits display strings.
+
+| State | Meaning |
+|---|---|
+| `queued` | Held by the process-wide concurrency semaphore (rare; only fires if ≥ `MAX_CONCURRENT_PROVISIONS` provisions in flight) |
+| `finding_gpu` | `selectPlacement` iterating DCs for 5090 spot stock |
+| `creating_pod` | `createSpotPod` / `createOnDemandPod` RPC in flight |
+| `fetching_image` | Pod created; waiting for `pod.runtime` (GHCR image pull — dominant time) |
+| `warming_model` | Container up; polling `/health` while FLUX model loads into GPU |
+| `connecting` | Pod `/health` ok; backend wiring the iOS↔pod frame relay |
+| `ready` | Relay live; iOS can stream |
+| `failed` | Unrecoverable error; `failureCategory` attached; WS closes after |
+| `terminated` | Session ended (reaped idle / aborted / replaced out) |
+
+`replacementCount` distinguishes fresh provisions (0) from preemption recoveries (1+). iOS prefixes display text with "Replacing — " when `replacementCount > 0`.
+
+Every transition also fires a `pod.state.entered` PostHog event with `previous_state` + `previous_state_duration_ms` — per-stage duration analysis is a one-line HogQL query.
 
 ## Network volumes
 


### PR DESCRIPTION
## Summary

Documentation pass after the state-machine refactor series (PRs #27, #29, #31, #35, #36, #37, #39).

- **\`documents/decisions.md\`** — new entry documenting the structured-state refactor. Captures the context (14 free-form strings, joiner bug, overlapping state machines), the decision (single flat enum + broker + client-owned display text), alternatives we considered + rejected (and why), and consequences for future changes (including the 5-spot checklist for adding a new state).
- **\`documents/references/provider-config.md\`** — replace the stale \"Status messages shown to user during provision\" section that listed the old free-form strings. Replaced with a table of the current \`State\` enum values and pointers to \`orchestrator.ts\` + \`ProvisionState.swift\` as the authoritative definitions.

No code changes; docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)