### PR TITLE
Redesign prompt bar + keyboard behavior

### DIFF
--- a/ios/Kiki/App/KeyboardDismissal.swift
+++ b/ios/Kiki/App/KeyboardDismissal.swift
@@ -1,0 +1,67 @@
+import UIKit
+
+/// Installs a window-level gesture recognizer that dismisses the keyboard
+/// on any touch that doesn't originate inside a `UITextField`/`UITextView`.
+/// `cancelsTouchesInView = false` means touches still reach their normal
+/// targets — buttons fire, canvas strokes draw — while the keyboard also
+/// dismisses.
+enum KeyboardDismissal {
+    static func installIfNeeded() {
+        Installer.shared.install()
+    }
+}
+
+private final class AnyTouchGestureRecognizer: UIGestureRecognizer {
+    override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent) {
+        super.touchesBegan(touches, with: event)
+        if state == .possible { state = .recognized }
+    }
+    override func touchesEnded(_ touches: Set<UITouch>, with event: UIEvent) {
+        state = .ended
+    }
+    override func touchesCancelled(_ touches: Set<UITouch>, with event: UIEvent) {
+        state = .cancelled
+    }
+}
+
+private final class Installer: NSObject, UIGestureRecognizerDelegate {
+    static let shared = Installer()
+    private weak var installedOn: UIWindow?
+
+    func install() {
+        guard installedOn == nil else { return }
+        guard let scene = UIApplication.shared.connectedScenes
+                .first(where: { $0.activationState == .foregroundActive }) as? UIWindowScene,
+              let window = scene.windows.first(where: \.isKeyWindow) ?? scene.windows.first else {
+            return
+        }
+        let gr = AnyTouchGestureRecognizer(target: self, action: #selector(handleTouch))
+        gr.cancelsTouchesInView = false
+        gr.delegate = self
+        window.addGestureRecognizer(gr)
+        installedOn = window
+    }
+
+    @objc private func handleTouch() {
+        UIApplication.shared.sendAction(
+            #selector(UIResponder.resignFirstResponder),
+            to: nil, from: nil, for: nil
+        )
+    }
+
+    func gestureRecognizer(_ gr: UIGestureRecognizer, shouldReceive touch: UITouch) -> Bool {
+        var current: UIView? = touch.view
+        while let v = current {
+            if v is UITextField || v is UITextView { return false }
+            current = v.superview
+        }
+        return true
+    }
+
+    func gestureRecognizer(
+        _ gr: UIGestureRecognizer,
+        shouldRecognizeSimultaneouslyWith other: UIGestureRecognizer
+    ) -> Bool {
+        true
+    }
+}

--- a/ios/Kiki/Views/DrawingView.swift
+++ b/ios/Kiki/Views/DrawingView.swift
@@ -139,6 +139,8 @@ struct DrawingView: View {
             }
         }
         .animation(.easeInOut(duration: 0.3), value: coordinator.generationError != nil)
+        .ignoresSafeArea(.keyboard)
+        .onAppear { KeyboardDismissal.installIfNeeded() }
         .fullScreenCover(isPresented: $coordinator.showStylePicker) {
             StylePickerView()
                 .environment(coordinator)
@@ -156,8 +158,6 @@ struct DrawingView: View {
             )
             .overlay(alignment: .top) {
                 PromptTitleBar()
-                    .padding(.top, 8)
-                    .padding(.horizontal, 24)
             }
             .overlay(alignment: .bottomLeading) {
                 connectionStatusIndicator
@@ -229,46 +229,68 @@ struct DrawingView: View {
 
 private struct PromptTitleBar: View {
     @Environment(AppCoordinator.self) private var coordinator
-    // Plain @State rather than @FocusState — the latter causes SwiftUI to
-    // auto-generate an InputAccessoryGenerator view for prev/next keyboard
-    // navigation, which (on iPad) triggers a constraint conflict with the
-    // SystemInputAssistantView and adds ~1s to TextField tap latency.
-    @State private var isFocused: Bool = false
+    // Fixed content height — both the style tile and the prompt input stay
+    // this tall regardless of text length. Long prompts scroll inside the
+    // TextEditor rather than growing the bar.
+    private static let contentHeight: CGFloat = 92
+    private static let cornerRadius: CGFloat = 10
 
     var body: some View {
         @Bindable var coordinator = coordinator
 
-        VStack(spacing: 10) {
-            Button {
-                coordinator.showStylePicker = true
-            } label: {
-                Text(coordinator.selectedStyle.name.uppercased())
+        HStack(alignment: .center, spacing: 8) {
+            styleButton
+            promptInput
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 16)
+    }
+
+    private var styleButton: some View {
+        Button {
+            coordinator.showStylePicker = true
+        } label: {
+            VStack(spacing: 4) {
+                Text("STYLE")
                     .font(.caption2.weight(.semibold))
-                    .tracking(1.4)
-                    .padding(.horizontal, 10)
-                    .padding(.vertical, 5)
-                    .background(Color.accentColor.opacity(0.12), in: Capsule())
+                    .tracking(1.2)
+                    .foregroundStyle(.secondary)
+                Text(coordinator.selectedStyle.name)
+                    .font(.subheadline.weight(.semibold))
+                    .multilineTextAlignment(.center)
+                    .minimumScaleFactor(0.75)
+                    .lineLimit(2)
                     .foregroundStyle(Color.accentColor)
             }
-
-            TextField(
-                "Describe your image…",
-                text: $coordinator.promptText,
-                onEditingChanged: { editing in isFocused = editing }
+            .padding(.horizontal, 6)
+            .frame(width: Self.contentHeight, height: Self.contentHeight)
+            .background(Color(.secondarySystemBackground), in: RoundedRectangle(cornerRadius: Self.cornerRadius))
+            .overlay(
+                RoundedRectangle(cornerRadius: Self.cornerRadius)
+                    .stroke(Color.accentColor.opacity(0.7), lineWidth: 1)
             )
-            .textFieldStyle(.plain)
-            .font(.title3.weight(.medium))
-            .multilineTextAlignment(.center)
-            .padding(.horizontal, 14)
-            .padding(.vertical, 8)
-            .overlay(alignment: .bottom) {
-                Rectangle()
-                    .fill(isFocused ? Color.accentColor : Color.secondary.opacity(0.35))
-                    .frame(height: isFocused ? 1.5 : 1)
-                    .animation(.easeInOut(duration: 0.15), value: isFocused)
-            }
-            .frame(maxWidth: 520)
         }
+        .buttonStyle(.plain)
+    }
+
+    // Multi-line text input. `lineLimit(4, reservesSpace: true)` reserves
+    // ~4 lines of height so the bar stays at a fixed initial size; extra
+    // text scrolls internally once the limit is reached.
+    private var promptInput: some View {
+        @Bindable var coordinator = coordinator
+        return TextField(
+            "Describe your image…",
+            text: $coordinator.promptText,
+            axis: .vertical
+        )
+        .textFieldStyle(.plain)
+        .font(.subheadline)
+        .lineLimit(4, reservesSpace: true)
+        .padding(.horizontal, 12)
+        .padding(.vertical, 10)
+        .frame(maxWidth: .infinity, alignment: .topLeading)
+        .frame(height: Self.contentHeight)
+        .background(Color(.secondarySystemBackground), in: RoundedRectangle(cornerRadius: Self.cornerRadius))
     }
 }
 


### PR DESCRIPTION
## Summary
- **Prompt bar**: horizontal layout — square STYLE tile (with accent border) on the left + multi-line TextField with a darker filled rounded rect on the right. Smaller font than before. Fixed ~92pt height; long text scrolls inside the field.
- **Keyboard no longer squishes the UI**: `.ignoresSafeArea(.keyboard)` on the root DrawingView VStack so the keyboard slides over the canvas/result pane instead of resizing them.
- **Tap anywhere outside the text field dismisses the keyboard**: new `KeyboardDismissal.installIfNeeded()` helper attaches a window-level `UIGestureRecognizer` with `cancelsTouchesInView = false`. A delegate skips touches originating inside a `UITextField`/`UITextView`, so tapping the field itself preserves focus. Every other touch — canvas stroke, tool button, pinch/rotate, tap on empty space — dismisses.

## Test plan
- [ ] Tap the text field → field focuses, keyboard appears, nothing shifts upward.
- [ ] With keyboard up, tap a tool button → tool changes AND keyboard dismisses.
- [ ] With keyboard up, start drawing on the canvas → stroke draws AND keyboard dismisses.
- [ ] With keyboard up, tap inside the text field → focus preserved, keyboard stays.
- [ ] Type a long prompt (4+ lines) → field scrolls internally, height stays fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)