### PR TITLE
feat(video): drawing-stopped LTXV animation (two-pod)

### DIFF
--- a/backend/scripts/sync-flux-app.ts
+++ b/backend/scripts/sync-flux-app.ts
@@ -334,7 +334,7 @@ python3 -c "import diffusers; print('diffusers:', diffusers.__version__, diffuse
 
 echo "=== SMOKE TEST ==="
 # Asserts (1) base-image torch is still active (venv didn't accidentally install
-# a conflicting torch), and (2) all runtime imports resolve.
+# a conflicting torch), and (2) all runtime imports resolve (image + video pods).
 python3 - <<'PYEOF'
 import sys
 import torch
@@ -343,8 +343,15 @@ assert '/usr/local/lib/python3.12/dist-packages' in torch.__file__, f'torch path
 assert torch.cuda.is_available(), 'CUDA not available'
 # Runtime imports — any ImportError here means the sync is broken for prod use.
 from diffusers import Flux2KleinPipeline  # noqa: F401
+from diffusers import LTXImageToVideoPipeline, LTXVideoTransformer3DModel  # noqa: F401
 import transformers, accelerate, safetensors, huggingface_hub, PIL, fastapi, uvicorn, websockets, sentencepiece  # noqa: F401
-print('smoke OK')
+import imageio_ffmpeg  # noqa: F401  -- video pod MP4 encoder
+# Ensure the bundled ffmpeg binary is actually present (imageio-ffmpeg lazy-
+# downloads it on first call to get_ffmpeg_exe; do that here so first video
+# request doesn't pay that cost on a cold pod).
+ff = imageio_ffmpeg.get_ffmpeg_exe()
+import os; assert os.path.exists(ff), f'ffmpeg missing: {ff}'
+print('smoke OK; ffmpeg at', ff)
 PYEOF
 
 echo "=== DONE ==="

--- a/backend/scripts/sync-flux-app.ts
+++ b/backend/scripts/sync-flux-app.ts
@@ -62,12 +62,16 @@ if (!SSH_KEY) {
 // mount the network volume. RunPod requires gpuCount ≥ 1, so we try an
 // ordered list of cheap GPUs (cheapest first) and use whichever one has
 // capacity in the target DC. Set SYNC_GPU_TYPE_ID to pin a specific type.
+// 4090 deliberately omitted: hosts in EUR-NO-1 + US-IL-1 boot the
+// container but `startSsh:true` never opens port 22 (verified across 3
+// retries, 2026-04-27). The cheaper tiers above + 5090 fallback are
+// proven to work. 5090 last so we don't pay the premium when a cheap
+// host is available.
 const DEFAULT_GPU_CANDIDATES = [
   'NVIDIA RTX 2000 Ada Generation',
   'NVIDIA RTX A4000',
   'NVIDIA GeForce RTX 3090',
   'NVIDIA L4',
-  'NVIDIA GeForce RTX 4090',
   'NVIDIA GeForce RTX 5090',
 ];
 const GPU_CANDIDATES = process.env['SYNC_GPU_TYPE_ID']

--- a/backend/src/config/index.ts
+++ b/backend/src/config/index.ts
@@ -35,6 +35,13 @@ export interface AppConfig {
    * removing the spot code path. Default false. */
   readonly ONDEMAND_ONLY_MODE: boolean;
 
+  /** When true, stream.ts provisions a video pod alongside the image pod for
+   * each session. When false, sessions are image-only and queueEmpty triggers
+   * log 'video_skipped: relay_disconnected' (same code path as a runtime
+   * provision failure). Lets us deploy backend-side video changes ahead of
+   * the pod-side code reaching every network volume. Default false. */
+  readonly VIDEO_POD_ENABLED: boolean;
+
   // ─── Network volumes (pre-populated with weights, venv, app code) ────
   /** Map of RunPod datacenter ID → network volume ID. Each volume is
    * pre-populated by scripts/populate-volume.ts (FLUX weights at
@@ -195,6 +202,7 @@ function validateConfig(): AppConfig {
     AUTH_REQUIRED: process.env['AUTH_REQUIRED'] === 'true',
     FREE_TIER_SECONDS: Number(process.env['FREE_TIER_SECONDS'] ?? 3600),
     ONDEMAND_FALLBACK_ENABLED: process.env['ONDEMAND_FALLBACK_ENABLED'] === 'true',
+    VIDEO_POD_ENABLED: process.env['VIDEO_POD_ENABLED'] === 'true',
     ONDEMAND_ONLY_MODE: process.env['ONDEMAND_ONLY_MODE'] === 'true',
     NETWORK_VOLUMES_BY_DC: parseVolumesMap(process.env['NETWORK_VOLUMES_BY_DC']),
     REDIS_URL: process.env['REDIS_URL'] ?? '',

--- a/backend/src/modules/orchestrator/orchestrator.ts
+++ b/backend/src/modules/orchestrator/orchestrator.ts
@@ -207,6 +207,65 @@ const IDLE_TIMEOUT_MS = 30 * 60 * 1000;
 const REAPER_INTERVAL_MS = 60 * 1000;
 const MAX_CONCURRENT_PROVISIONS = Number(process.env['MAX_CONCURRENT_PROVISIONS'] ?? 5);
 
+// ────────────────────────────────────────────────────────────────────────────
+// Pod kinds: one operation (provision a pod) parameterized by a small static
+// config. POD_CONFIGS holds the six values that genuinely differ between
+// image and video pods. Everything else — DC selection, reroll on stall,
+// runtime+health waits, in-process inFlight dedup, idle reaping, reconcile —
+// is shared machinery in `_runProvisionLoop` / `_getOrProvisionPod` /
+// `_replacePodSession` (this file). Public per-kind exports (getOrProvisionPod,
+// getOrProvisionVideoPod, replaceSession, replaceVideoSession) are thin
+// wrappers expressing the per-kind contract differences (image: throws on
+// failure; video: returns null, best-effort).
+//
+// Adding a new pod kind = add a row to POD_CONFIGS + thin public wrappers.
+// No new architecture, no new Redis schema field, no new inFlight map.
+// ────────────────────────────────────────────────────────────────────────────
+
+export type PodKind = 'image' | 'video';
+
+interface PodKindConfig {
+  /** Pod name prefix (must be unique per kind so reconcile + Discord alerts
+   *  can list each kind separately). */
+  namePrefix: string;
+  /** Container entrypoint. Differs by kind only in which python script. */
+  bootDockerArgs: string;
+  /** RunPod proxy port for this pod's HTTP/WS service. */
+  port: number;
+  /** Watchdog budget for `waitForRuntime`. Image: 45 s (handles by reroll).
+   *  Video: 180 s (cold image pulls on a fresh host need more headroom; we
+   *  do still reroll, just give each DC more time before giving up). */
+  stallMs: number;
+  /** Create a pod for the chosen DC. Image: spot then on-demand fallback.
+   *  Video: on-demand only (preemption recovery via replaceVideoSession is
+   *  cleaner than spot complexity at our scale). */
+  createPodForDc: (
+    target: PlacementTarget,
+    sessionId: string,
+  ) => Promise<{ podId: string; podType: PodType; dc: string | null }>;
+  /** Look up a reusable pod from an existing session row. null if none.
+   *  Image: trusts row.state === 'ready' && row.podUrl (fast Redis-only).
+   *  Video: row.videoPodId set AND getPod returns RUNNING+runtime
+   *  (~500 ms RunPod query — needed because video doesn't have a state
+   *  field; deferred state-emit follow-up would let video also do
+   *  Redis-only). */
+  getReusableFromRow: (
+    row: RedisSession,
+  ) => Promise<{ podId: string; podUrl: string } | null>;
+  /** Stamp the row with the new pod's identity after provision succeeds.
+   *  Image: { podId, podUrl, podType } — full set, since image's reuse
+   *  check reads podUrl from the row. Video: { videoPodId } — minimal,
+   *  since video's reuse check uses RunPod query. */
+  stampRow: (
+    sessionId: string,
+    pod: { podId: string; podUrl: string; podType: PodType },
+  ) => Promise<void>;
+}
+
+// `POD_CONFIGS: Record<PodKind, PodKindConfig>` is defined further below,
+// after the helper functions it closes over (createPodWithFallback,
+// createOnDemandPod, getPod, patchSession). Search for `const POD_CONFIGS`.
+
 // Semaphore state
 let activeProvisions = 0;
 const semaphoreWaiters: Array<() => void> = [];
@@ -1048,186 +1107,40 @@ function handleRecoverableProvisionError(
   return { decision: willReroll ? 'retry' : 'abort', errDc };
 }
 
+/**
+ * Thin image-pod wrapper around _runProvisionLoop. Adds image-specific
+ * outer concerns: parent Sentry span; emitState + Discord notify between
+ * phases (drives the iPad's "Finding GPU... Creating pod..." overlay);
+ * terminal `failed` state emit on giveup.
+ *
+ * The helper does the actual mechanics (selectPlacement → create → wait
+ * for runtime + health, retry across DCs on stall/vanish) and the cross-
+ * kind concerns (analytics, Sentry exception capture).
+ */
 async function provision(sessionId: string): Promise<ProvisionResult> {
   return Sentry.startSpan(
     { name: 'pod.provision', op: 'pod.provision', attributes: { sessionId } },
-    async (parentSpan) => {
-      const t0 = Date.now();
-      const blacklistedDcs = new Set<string>();
-      const maxRerolls = Math.max(0, config.POD_BOOT_MAX_REROLLS);
-
-      for (let attempt = 0; attempt <= maxRerolls; attempt++) {
-        let podId: string | null = null;
-        let podType: PodType | null = null;
-        let dc: string | null = null;
-        // `currentState` tracks the last state we emitted, used for error-path
-        // analytics tagging. Starts at 'finding_gpu' because caller set that.
-        let currentState: State = 'finding_gpu';
-        const attemptStart = Date.now();
-        let phaseStart = attemptStart;
-        const phaseTimings: Record<string, number> = {};
-
-        // On reroll (attempt > 0), we need to return the UI to 'finding_gpu'
-        // before the next pod create attempt. Idempotent on first iteration.
-        if (attempt > 0) {
-          await emitState(sessionId, 'finding_gpu');
-          currentState = 'finding_gpu';
-        }
-
-        trackPodProvisionStarted({
-          userId: sessionId,
-          attempt,
-          excludedDcs: Array.from(blacklistedDcs),
+    async () => {
+      try {
+        const result = await _runProvisionLoop('image', sessionId, {
+          onProvisionPhase: async (phase, podId) => {
+            await emitState(sessionId, phase);
+            if (podId && phase === 'fetching_image') {
+              notifyPodProgress(podId, '⏳ Fetching container image...');
+            } else if (podId && phase === 'warming_model') {
+              notifyPodProgress(podId, '🧠 Warming up AI model...');
+            }
+          },
         });
-
-        try {
-          // 1 + 2. Create a pod — spot first, on-demand fallback if capacity exhausted.
-          // `createPodWithFallback` emits 'creating_pod' right before the create RPC.
-          const created = await Sentry.startSpan(
-            { name: 'pod.create', op: 'pod.create', attributes: { sessionId, attempt } },
-            () => createPodWithFallback(sessionId, blacklistedDcs),
-          );
-          podId = created.podId;
-          podType = created.podType;
-          dc = created.dc;
-          currentState = 'creating_pod';
-
-          phaseTimings.creating_pod_ms = Date.now() - phaseStart;
-          phaseStart = Date.now();
-
-          Sentry.addBreadcrumb({
-            category: 'provision',
-            level: 'info',
-            message: 'Pod created',
-            data: { podId, dc, podType, attempt, creatingPodMs: phaseTimings.creating_pod_ms },
-          });
-
-          // If any subsequent step fails, terminate the pod we just created to prevent
-          // cost leaks. This matters especially for replaceSession() which calls
-          // provision() directly without its own pod cleanup.
-          try {
-            // 3. Wait for container to boot. Dominated by GHCR image pull (~60-90s).
-            await emitState(sessionId, 'fetching_image');
-            currentState = 'fetching_image';
-            notifyPodProgress(podId, '⏳ Fetching container image...');
-            await Sentry.startSpan(
-              { name: 'pod.fetching_image', op: 'pod.fetching_image', attributes: { podId, dc: dc ?? 'unknown', attempt } },
-              () => waitForRuntime(podId as string),
-            );
-            notifyPodProgress(podId, `📦 Container runtime up`);
-            phaseTimings.fetching_image_ms = Date.now() - phaseStart;
-            phaseStart = Date.now();
-
-            // 4. Poll /health via RunPod proxy until the FLUX server reports ready
-            await emitState(sessionId, 'warming_model');
-            currentState = 'warming_model';
-            notifyPodProgress(podId, '🧠 Warming up AI model...');
-            const healthUrl = `https://${podId}-8766.proxy.runpod.net/health`;
-            await Sentry.startSpan(
-              { name: 'pod.warming_model', op: 'pod.warming_model', attributes: { podId, dc: dc ?? 'unknown' } },
-              () => waitForHealth(podId as string, healthUrl),
-            );
-            phaseTimings.warming_model_ms = Date.now() - phaseStart;
-
-            const totalMs = Date.now() - t0;
-
-            // 5. Pod is serving. Persist pod info and return — stream.ts will
-            // emit 'connecting' / 'ready' once it wires up the iOS↔pod relay.
-            // Keeping the 'ready' emit out of provision() prevents a window
-            // where iOS sees 'ready' but the backend's relay isn't yet set up
-            // to forward its frames to the pod.
-            const podUrl = `wss://${podId}-8766.proxy.runpod.net/ws`;
-            await patchSession(sessionId, { podId, podUrl, podType });
-            log.info(
-              { sessionId, podId, podUrl, podType, totalMs, attempt, dc },
-              'Pod serving — awaiting relay',
-            );
-            notifyPodProgress(podId, `✅ **Pod serving** (${Math.round(totalMs / 1000)}s total)`);
-
-            parentSpan.setAttributes({
-              dc: dc ?? 'unknown',
-              podType,
-              attempt,
-              outcome: 'success',
-            });
-            trackPodProvisionCompleted({
-              userId: sessionId,
-              durationMs: Date.now() - attemptStart,
-              dc,
-              podType,
-              attempt,
-              phaseTimings,
-            });
-            return { podId, podUrl, podType };
-          } catch (err) {
-            // Pod was created but a later step failed — clean up to prevent cost leak.
-            log.warn(
-              { sessionId, podId, err: (err as Error).message, state: currentState, attempt },
-              'Provision failed after pod creation — terminating pod',
-            );
-            terminatePod(podId).catch((e) =>
-              log.warn({ podId, err: (e as Error).message }, 'Failed to terminate pod after provision failure'),
-            );
-            throw err;
-          }
-        } catch (err) {
-          // Recoverable classes (PodBootStallError, PodVanishedError) come
-          // from a flaky DC. The helper emits observability + decides whether
-          // we have rerolls left; on retry, blacklist the DC and loop.
-          const recovery = handleRecoverableProvisionError(err as Error, {
-            sessionId,
-            dc,
-            podType,
-            attempt,
-            maxRerolls,
-          });
-          if (recovery.decision === 'retry') {
-            if (recovery.errDc) blacklistedDcs.add(recovery.errDc);
-            continue;
-          }
-          // Fall through: unrecoverable error, or rerolls exhausted.
-
-          parentSpan.setAttributes({
-            dc: dc ?? 'unknown',
-            podType: podType ?? 'unknown',
-            attempt,
-            outcome: 'failure',
-            state: currentState,
-          });
-
-          const category = classifyProvisionError(err as Error);
-          Sentry.captureException(err, {
-            tags: {
-              dc: dc ?? 'unknown',
-              podType: podType ?? 'unknown',
-              state: currentState,
-              attempt: String(attempt),
-              category,
-            },
-            contexts: {
-              pod: {
-                id: podId ?? 'none',
-                sessionId,
-                elapsedSec: Math.round((Date.now() - t0) / 1000),
-              },
-            },
-          });
-          trackPodProvisionFailed({
-            userId: sessionId,
-            durationMs: Date.now() - attemptStart,
-            category,
-            dc,
-            state: currentState,
-            attempt,
-          });
-          // Transition to terminal failed state so subscribers see the final event.
-          await emitState(sessionId, 'failed', category);
-          throw err;
-        }
+        notifyPodProgress(result.podId, '✅ **Pod serving**');
+        return { podId: result.podId, podUrl: result.podUrl, podType: result.podType };
+      } catch (err) {
+        // Helper has already done analytics + Sentry capture. Layer on the
+        // image-only terminal-state emit so iPad subscribers see 'failed'.
+        const category = classifyProvisionError(err as Error);
+        await emitState(sessionId, 'failed', category);
+        throw err;
       }
-
-      // Unreachable — loop body either returns or throws. Kept for type-checker.
-      throw new Error('provision: reroll loop exited without resolution');
     },
   );
 }
@@ -1587,10 +1500,10 @@ async function selectPlacement(
  */
 async function createPodWithFallback(
   sessionId: string,
-  excludeDcs: ReadonlySet<string> = new Set(),
+  target: PlacementTarget,
+  podName: string,
+  bootDockerArgs: string,
 ): Promise<{ podId: string; podType: PodType; dc: string | null }> {
-  const podName = `${POD_PREFIX}${sessionId.slice(0, 16)}`;
-
   // Volume-entrypoint mode: stock RunPod pytorch image + our code/deps from
   // the attached network volume. See BASE_IMAGE / BOOT_DOCKER_ARGS / BOOT_ENV
   // constants near top of file. Replaces the previous GHCR custom-image flow —
@@ -1598,15 +1511,6 @@ async function createPodWithFallback(
   // that affected ~38% of provisions. See documents/decisions.md entry
   // 2026-04-23 for context + rollback procedure.
   const imageName = BASE_IMAGE;
-
-  // ─── Pick DC + volume (state stays 'finding_gpu' during selectPlacement) ──
-  const target = await selectPlacement(sessionId, excludeDcs);
-  if (!target) {
-    const suffix = excludeDcs.size > 0
-      ? ` (excluding ${Array.from(excludeDcs).join(',')} after earlier stall)`
-      : '';
-    throw new Error(`No RunPod DC has 5090 capacity right now (all volume-DCs exhausted)${suffix}`);
-  }
   const bidInfo = target.bidInfo;
   const dcField = target.dataCenterId ? { dataCenterId: target.dataCenterId } : {};
   const volField = target.networkVolumeId ? { networkVolumeId: target.networkVolumeId } : {};
@@ -1655,14 +1559,13 @@ async function createPodWithFallback(
       },
       'Spot bid discovered',
     );
-    await emitState(sessionId, 'creating_pod');
     try {
       const { id: podId, costPerHr } = await createSpotPod({
         name: podName,
         imageName,
         gpuTypeId: GPU_TYPE_ID,
         bidPerGpu: bid,
-        dockerArgs: BOOT_DOCKER_ARGS,
+        dockerArgs: bootDockerArgs,
         env: BOOT_ENV,
         containerRegistryAuthId: config.RUNPOD_REGISTRY_AUTH_ID,
         ...dcField,
@@ -1707,14 +1610,13 @@ async function createPodWithFallback(
     { sessionId, event: 'provision.fallback.triggered', reason: fallbackReason, dc: target.dataCenterId },
     'Switching to on-demand pod',
   );
-  await emitState(sessionId, 'creating_pod');
   try {
     const { id: podId, costPerHr } = await createOnDemandPod({
       name: podName,
       imageName,
       gpuTypeId: GPU_TYPE_ID,
       cloudType: 'SECURE',
-      dockerArgs: BOOT_DOCKER_ARGS,
+      dockerArgs: bootDockerArgs,
       env: BOOT_ENV,
       containerRegistryAuthId: config.RUNPOD_REGISTRY_AUTH_ID,
       ...dcField,
@@ -1733,6 +1635,264 @@ async function createPodWithFallback(
     );
     throw err;
   }
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// POD_CONFIGS — see PodKindConfig declaration near top of file for the rules.
+// Defined here so it can close over createPodWithFallback / createOnDemandPod.
+// ────────────────────────────────────────────────────────────────────────────
+
+const POD_CONFIGS: Record<PodKind, PodKindConfig> = {
+  image: {
+    namePrefix: POD_PREFIX,
+    bootDockerArgs: BOOT_DOCKER_ARGS,
+    port: 8765,
+    stallMs: config.POD_BOOT_WATCHDOG_ENABLED ? config.POD_BOOT_STALL_MS : Infinity,
+    createPodForDc: (target, sessionId) => {
+      const podName = `${POD_PREFIX}${sessionId.slice(0, 16)}`;
+      return createPodWithFallback(sessionId, target, podName, BOOT_DOCKER_ARGS);
+    },
+    // Image: trust the row's persisted state. `state === 'ready'` is set by
+    // stream.ts after the relay is wired (full session readiness), so this
+    // single Redis hash read replaces a ~500 ms RunPod query. The rare
+    // "row says ready but pod is gone" case is handled downstream by
+    // `wireRelay`'s onClose → replaceSession path.
+    getReusableFromRow: async (row) => {
+      if (row.state === 'ready' && row.podUrl && row.podId) {
+        return { podId: row.podId, podUrl: row.podUrl };
+      }
+      return null;
+    },
+    stampRow: (sessionId, pod) =>
+      patchSession(sessionId, { podId: pod.podId, podUrl: pod.podUrl, podType: pod.podType }),
+  },
+  video: {
+    namePrefix: VIDEO_POD_PREFIX,
+    bootDockerArgs: BOOT_DOCKER_ARGS_VIDEO,
+    port: 8766,
+    // Cold image pulls on a fresh host take 60-180s. Image pod can reroll
+    // on stall fast (45s); video pod also rerolls now via _runProvisionLoop,
+    // but giving each attempt more headroom reduces total reroll cost.
+    stallMs: 180_000,
+    createPodForDc: async (target, sessionId) => {
+      const podName = `${VIDEO_POD_PREFIX}${sessionId.slice(0, 16)}`;
+      const dcField = target.dataCenterId ? { dataCenterId: target.dataCenterId } : {};
+      const volField = target.networkVolumeId ? { networkVolumeId: target.networkVolumeId } : {};
+      const result = await createOnDemandPod({
+        name: podName,
+        imageName: BASE_IMAGE,
+        gpuTypeId: GPU_TYPE_ID,
+        cloudType: 'SECURE',
+        dockerArgs: BOOT_DOCKER_ARGS_VIDEO,
+        env: BOOT_ENV,
+        containerRegistryAuthId: config.RUNPOD_REGISTRY_AUTH_ID,
+        ...dcField,
+        ...volField,
+      });
+      return { podId: result.id, podType: 'onDemand', dc: target.dataCenterId };
+    },
+    // Video: row only has `videoPodId`; no state field. Probe RunPod for
+    // RUNNING+runtime as the readiness signal. ~500ms cost on every
+    // reconnect — acceptable because video reconnects are less frequent
+    // than image's per-message touch traffic.
+    getReusableFromRow: async (row) => {
+      if (!row.videoPodId) return null;
+      const pod = await getPod(row.videoPodId).catch(() => null);
+      if (pod && pod.desiredStatus === 'RUNNING' && pod.runtime !== null) {
+        return {
+          podId: row.videoPodId,
+          podUrl: `wss://${row.videoPodId}-8766.proxy.runpod.net/ws`,
+        };
+      }
+      return null;
+    },
+    stampRow: (sessionId, pod) =>
+      patchSession(sessionId, { videoPodId: pod.podId }),
+  },
+};
+
+/**
+ * Shared pod-spinup mechanics: select a DC, create a pod for it, wait for
+ * runtime + health, retry across DCs on stall/vanish. The kind parameter
+ * drives all pod-specific differences via `POD_CONFIGS[kind]` — no
+ * conditionals on `kind` in the loop body.
+ *
+ * Caller hooks:
+ *   - `opts.onProvisionPhase(phase, podId)`: called inside the loop at each
+ *     state transition. Image pod's `provision()` wrapper supplies a
+ *     callback that does `emitState` + `notifyPodProgress`. Video doesn't
+ *     supply one, so video provisioning is silent on the broker.
+ *   - `opts.preferredDc`: if set, floats to the top of the placement
+ *     ranking when stock is non-zero. Used by video to co-locate with
+ *     the image pod's DC.
+ *
+ * Throws `PodBootStallError` / `PodVanishedError` (recoverable, but only
+ * after exhausting `POD_BOOT_MAX_REROLLS`) or any other error from the
+ * underlying RunPod / health-check APIs (terminal). Image's `provision()`
+ * wrapper catches these and re-throws after analytics; video's caller
+ * catches and returns null for best-effort behavior.
+ */
+async function _runProvisionLoop(
+  kind: PodKind,
+  sessionId: string,
+  opts: {
+    preferredDc?: string;
+    onProvisionPhase?: (phase: State, podId: string | null) => Promise<void>;
+  } = {},
+): Promise<{ podId: string; podUrl: string; podType: PodType; dc: string | null }> {
+  const cfg = POD_CONFIGS[kind];
+  const t0 = Date.now();
+  const blacklistedDcs = new Set<string>();
+  const maxRerolls = Math.max(0, config.POD_BOOT_MAX_REROLLS);
+
+  for (let attempt = 0; attempt <= maxRerolls; attempt++) {
+    let podId: string | null = null;
+    let podType: PodType | null = null;
+    let dc: string | null = null;
+    let currentState: State = 'finding_gpu';
+    const attemptStart = Date.now();
+    let phaseStart = attemptStart;
+    const phaseTimings: Record<string, number> = {};
+
+    // On reroll, return the UI to 'finding_gpu' before the next pod create.
+    if (attempt > 0) {
+      await opts.onProvisionPhase?.('finding_gpu', null);
+      currentState = 'finding_gpu';
+    }
+
+    trackPodProvisionStarted({
+      userId: sessionId,
+      attempt,
+      excludedDcs: Array.from(blacklistedDcs),
+    });
+
+    try {
+      // 1 + 2. DC selection + pod create. Both are kind-specific via
+      // POD_CONFIGS[kind].createPodForDc — image goes spot-then-on-demand,
+      // video goes straight on-demand.
+      const target = await selectPlacement(sessionId, blacklistedDcs, opts.preferredDc);
+      if (!target) {
+        const suffix = blacklistedDcs.size > 0
+          ? ` (excluding ${Array.from(blacklistedDcs).join(',')} after earlier stall)`
+          : '';
+        throw new Error(`No RunPod DC has 5090 capacity right now (all volume-DCs exhausted)${suffix}`);
+      }
+      await opts.onProvisionPhase?.('creating_pod', null);
+      currentState = 'creating_pod';
+      const created = await Sentry.startSpan(
+        { name: 'pod.create', op: 'pod.create', attributes: { sessionId, kind, attempt } },
+        () => cfg.createPodForDc(target, sessionId),
+      );
+      podId = created.podId;
+      podType = created.podType;
+      dc = created.dc;
+
+      phaseTimings.creating_pod_ms = Date.now() - phaseStart;
+      phaseStart = Date.now();
+
+      Sentry.addBreadcrumb({
+        category: 'provision',
+        level: 'info',
+        message: 'Pod created',
+        data: { podId, dc, podType, kind, attempt, creatingPodMs: phaseTimings.creating_pod_ms },
+      });
+
+      try {
+        // 3. Wait for container to boot. Dominated by image pull.
+        await opts.onProvisionPhase?.('fetching_image', podId);
+        currentState = 'fetching_image';
+        await Sentry.startSpan(
+          { name: 'pod.fetching_image', op: 'pod.fetching_image', attributes: { podId, kind, dc: dc ?? 'unknown', attempt } },
+          () => waitForRuntime(podId as string, { stallMs: cfg.stallMs }),
+        );
+        phaseTimings.fetching_image_ms = Date.now() - phaseStart;
+        phaseStart = Date.now();
+
+        // 4. Poll /health until the server reports ready.
+        await opts.onProvisionPhase?.('warming_model', podId);
+        currentState = 'warming_model';
+        const healthUrl = `https://${podId}-${cfg.port}.proxy.runpod.net/health`;
+        await Sentry.startSpan(
+          { name: 'pod.warming_model', op: 'pod.warming_model', attributes: { podId, kind, dc: dc ?? 'unknown' } },
+          () => waitForHealth(podId as string, healthUrl),
+        );
+        phaseTimings.warming_model_ms = Date.now() - phaseStart;
+
+        const totalMs = Date.now() - t0;
+        const podUrl = `wss://${podId}-${cfg.port}.proxy.runpod.net/ws`;
+
+        // 5. Stamp the row with the kind-appropriate fields. Image:
+        // {podId, podUrl, podType}; video: {videoPodId}.
+        await cfg.stampRow(sessionId, { podId, podUrl, podType });
+
+        log.info(
+          { sessionId, kind, podId, podUrl, podType, totalMs, attempt, dc },
+          'Pod serving — awaiting relay',
+        );
+        trackPodProvisionCompleted({
+          userId: sessionId,
+          durationMs: Date.now() - attemptStart,
+          dc,
+          podType,
+          attempt,
+          phaseTimings,
+        });
+        return { podId, podUrl, podType, dc };
+      } catch (err) {
+        // Pod was created but a later step failed — clean up.
+        log.warn(
+          { sessionId, kind, podId, err: (err as Error).message, state: currentState, attempt },
+          'Provision failed after pod creation — terminating pod',
+        );
+        terminatePod(podId).catch((e) =>
+          log.warn({ podId, err: (e as Error).message }, 'Failed to terminate pod after provision failure'),
+        );
+        throw err;
+      }
+    } catch (err) {
+      // Recoverable classes (PodBootStallError, PodVanishedError) come from
+      // a flaky DC. The helper emits observability + decides whether we
+      // have rerolls left; on retry, blacklist the DC and loop.
+      const recovery = handleRecoverableProvisionError(err as Error, {
+        sessionId,
+        dc,
+        podType,
+        attempt,
+        maxRerolls,
+      });
+      if (recovery.decision === 'retry') {
+        if (recovery.errDc) blacklistedDcs.add(recovery.errDc);
+        continue;
+      }
+      // Terminal: classify, fire analytics, propagate.
+      const category = classifyProvisionError(err as Error);
+      Sentry.captureException(err, {
+        tags: {
+          dc: dc ?? 'unknown',
+          podType: podType ?? 'unknown',
+          state: currentState,
+          attempt: String(attempt),
+          category,
+          kind,
+        },
+        contexts: {
+          pod: { id: podId ?? 'none', sessionId, elapsedSec: Math.round((Date.now() - t0) / 1000) },
+        },
+      });
+      trackPodProvisionFailed({
+        userId: sessionId,
+        durationMs: Date.now() - attemptStart,
+        category,
+        dc,
+        state: currentState,
+        attempt,
+      });
+      throw err;
+    }
+  }
+
+  // Unreachable: loop body either returns or throws.
+  throw new Error('_runProvisionLoop: reroll loop exited without resolution');
 }
 
 /**

--- a/backend/src/modules/orchestrator/orchestrator.ts
+++ b/backend/src/modules/orchestrator/orchestrator.ts
@@ -793,7 +793,7 @@ async function runReaper(): Promise<void> {
       const videoPodId = data['videoPodId'] || null;
       const createdAt = Number(data['createdAt'] ?? 0);
       const lifetimeMs = createdAt > 0 ? now - createdAt : 0;
-      log.info({ sessionId, podId, videoPodId, idleMs, lifetimeMs, kind: 'image' }, '[reaper] terminating session=' + sessionId + ' kind=image');
+      log.info({ sessionId, podId, videoPodId, idleMs, lifetimeMs, kind: 'image' }, '[reaper] terminating idle session');
       trackPodTerminated({ userId: sessionId, reason: 'idle', lifetimeMs });
       notifyPodTerminated(podId, `idle ${Math.round(idleMs / 1000)}s`);
       // Emit through the broker so the iPad sees state='terminated' with
@@ -807,7 +807,7 @@ async function runReaper(): Promise<void> {
         .then(() => redis.del(key))
         .catch((err) => log.error({ sessionId, podId, err }, 'Reap failed'));
       if (videoPodId) {
-        log.info({ sessionId, videoPodId, kind: 'video' }, '[reaper] terminating session=' + sessionId + ' kind=video');
+        log.info({ sessionId, videoPodId, kind: 'video' }, '[reaper] terminating video pod alongside image');
         terminatePod(videoPodId).catch((err) =>
           log.error({ sessionId, videoPodId, err }, 'Reap video pod failed'),
         );

--- a/backend/src/modules/orchestrator/orchestrator.ts
+++ b/backend/src/modules/orchestrator/orchestrator.ts
@@ -162,6 +162,10 @@ export type PodType = 'spot' | 'onDemand';
 // Session registry lives in Redis (WS5). Local map only holds in-flight
 // provision promises for same-process join (Promises can't be serialized).
 const inFlightProvisions = new Map<string, Promise<{ podUrl: string }>>();
+// Same idea for video pods. Closes the in-process race where a quick
+// iPad reconnect during a video pod's boot would otherwise trigger a
+// second provision before the first one's videoPodId is on the row.
+const inFlightVideoProvisions = new Map<string, Promise<{ podId: string; podUrl: string } | null>>();
 
 const SESSION_PREFIX = 'session:';
 const POD_PREFIX = 'kiki-session-';
@@ -1305,8 +1309,19 @@ export async function provisionVideoPod(
     return null;
   }
 
+  // Stamp videoPodId on the session row immediately, before waiting for
+  // boot. Otherwise a quick iPad reconnect during the 60-180s boot window
+  // hits getOrProvisionVideoPod with a row whose videoPodId is still null,
+  // and starts a SECOND pod — both then race the stall watchdog and both
+  // get terminated. Stamping here closes that window.
+  await setVideoPod(sessionId, podId);
+
   try {
-    await waitForRuntime(podId);
+    // Bump stallMs to 180s for video pods. Default 45s isn't enough for
+    // a cold image pull on a fresh host, and unlike the image-pod path
+    // we don't reroll DCs on stall — a single stall = no video for this
+    // session. 180s comfortably covers a slow Docker Hub pull.
+    await waitForRuntime(podId, { stallMs: 180_000 });
     const healthUrl = `https://${podId}-8766.proxy.runpod.net/health`;
     await waitForHealth(podId, healthUrl);
     const podUrl = `wss://${podId}-8766.proxy.runpod.net/ws`;
@@ -1323,6 +1338,9 @@ export async function provisionVideoPod(
     terminatePod(podId).catch((e) =>
       log.warn({ podId, err: (e as Error).message }, '[provision/video] terminate-after-fail failed'),
     );
+    // Clear the row stamp we wrote above so the next reconnect does a
+    // fresh provision instead of probing this dead pod.
+    await clearVideoPod(sessionId).catch(() => {});
     return null;
   }
 }
@@ -1394,13 +1412,54 @@ export async function getOrProvisionVideoPod(
       );
       return { podId: existing.videoPodId, podUrl };
     }
-    log.info(
-      { sessionId, videoPodId: existing.videoPodId, status: pod?.desiredStatus ?? 'gone', pod_kind: 'video', event: '[provision/video] stale id' },
-      '[provision/video] stashed videoPodId is stale; reprovisioning',
-    );
+    if (pod && pod.desiredStatus === 'RUNNING' && pod.runtime === null) {
+      // Pod exists and is desired-running, but runtime hasn't appeared
+      // yet — it's mid-boot, likely from a concurrent in-flight provision
+      // on this same backend instance. Joining the in-flight promise (if
+      // present) gets us the correct result without starting a duplicate.
+      const inFlight = inFlightVideoProvisions.get(sessionId);
+      if (inFlight) {
+        log.info(
+          { sessionId, videoPodId: existing.videoPodId, pod_kind: 'video', event: '[provision/video] joined in-flight' },
+          '[provision/video] pod still booting; joining in-flight provision',
+        );
+        return inFlight;
+      }
+      // Booting but not in-flight on this instance — likely a different
+      // backend replica owns it, or the original promise lost track on
+      // restart. Fall through to fresh provision; the orphan will be
+      // cleaned up by reconcile.
+      log.warn(
+        { sessionId, videoPodId: existing.videoPodId, pod_kind: 'video' },
+        '[provision/video] pod booting but no in-flight promise here; reprovisioning',
+      );
+    } else {
+      log.info(
+        { sessionId, videoPodId: existing.videoPodId, status: pod?.desiredStatus ?? 'gone', pod_kind: 'video', event: '[provision/video] stale id' },
+        '[provision/video] stashed videoPodId is stale; reprovisioning',
+      );
+    }
     await clearVideoPod(sessionId).catch(() => {});
   }
-  return provisionVideoPod(sessionId);
+
+  const inFlight = inFlightVideoProvisions.get(sessionId);
+  if (inFlight) {
+    log.info(
+      { sessionId, pod_kind: 'video', event: '[provision/video] joined in-flight' },
+      '[provision/video] joining in-flight provision (no row stamp yet)',
+    );
+    return inFlight;
+  }
+
+  const promise = (async () => {
+    try {
+      return await provisionVideoPod(sessionId);
+    } finally {
+      inFlightVideoProvisions.delete(sessionId);
+    }
+  })();
+  inFlightVideoProvisions.set(sessionId, promise);
+  return promise;
 }
 
 /**

--- a/backend/src/modules/orchestrator/orchestrator.ts
+++ b/backend/src/modules/orchestrator/orchestrator.ts
@@ -1367,6 +1367,42 @@ export async function clearVideoPod(sessionId: string): Promise<void> {
 }
 
 /**
+ * Get-or-provision the video pod for a session. Mirrors getOrProvisionPod
+ * for image pods: on iPad WS reconnect, the video pod outlives the WS and
+ * is reused, avoiding the ~3-min LTXV cold start on every drawing change.
+ *
+ * Returns null on any provision failure (best-effort, same contract as
+ * provisionVideoPod).
+ *
+ * Stale-id handling: if the session row references a videoPodId that's
+ * gone from RunPod (terminated externally, reconciled, etc.), we clear
+ * the stale id and provision fresh.
+ */
+export async function getOrProvisionVideoPod(
+  sessionId: string,
+): Promise<{ podId: string; podUrl: string } | null> {
+  const existing = await readSession(sessionId);
+  if (existing?.videoPodId) {
+    const pod = await getPod(existing.videoPodId).catch(() => null);
+    const ready = pod && pod.desiredStatus === 'RUNNING' && pod.runtime !== null;
+    if (ready) {
+      const podUrl = `wss://${existing.videoPodId}-8766.proxy.runpod.net/ws`;
+      log.info(
+        { sessionId, videoPodId: existing.videoPodId, pod_kind: 'video', event: '[provision/video] reused' },
+        '[provision/video] reusing existing pod (no cold start)',
+      );
+      return { podId: existing.videoPodId, podUrl };
+    }
+    log.info(
+      { sessionId, videoPodId: existing.videoPodId, status: pod?.desiredStatus ?? 'gone', pod_kind: 'video', event: '[provision/video] stale id' },
+      '[provision/video] stashed videoPodId is stale; reprovisioning',
+    );
+    await clearVideoPod(sessionId).catch(() => {});
+  }
+  return provisionVideoPod(sessionId);
+}
+
+/**
  * A candidate placement: which DC to pin the pod to, and optionally which
  * pre-populated network volume to attach. `null` for both means "let RunPod
  * pick any DC, no volume" — only hit when NETWORK_VOLUMES_BY_DC is empty

--- a/backend/src/modules/orchestrator/orchestrator.ts
+++ b/backend/src/modules/orchestrator/orchestrator.ts
@@ -1251,11 +1251,12 @@ async function provision(sessionId: string): Promise<ProvisionResult> {
 
 export async function provisionVideoPod(
   sessionId: string,
+  preferredDc?: string,
 ): Promise<{ podId: string; podUrl: string } | null> {
   const t0 = Date.now();
   let target: PlacementTarget | null;
   try {
-    target = await selectPlacement(sessionId);
+    target = await selectPlacement(sessionId, undefined, preferredDc);
   } catch (err) {
     log.warn(
       { sessionId, err: (err as Error).message, event: '[provision/video] selectPlacement failed' },
@@ -1451,9 +1452,24 @@ export async function getOrProvisionVideoPod(
     return inFlight;
   }
 
+  // Co-locate with the image pod's DC if we know it. The image pod may
+  // already be in a working DC (possibly via reroll) — sticking the video
+  // pod there avoids cross-DC trigger latency AND avoids landing the
+  // video pod in a DC that's currently broken (e.g. US-NC-1 host issues
+  // we've seen). If the image pod hasn't been placed yet (parallel
+  // provision starting up), we have no preference and fall back to
+  // selectPlacement's default ranking.
+  let preferredDc: string | undefined;
+  if (existing?.podId) {
+    const imagePod = await getPod(existing.podId).catch(() => null);
+    if (imagePod?.machine?.dataCenterId) {
+      preferredDc = imagePod.machine.dataCenterId;
+    }
+  }
+
   const promise = (async () => {
     try {
-      return await provisionVideoPod(sessionId);
+      return await provisionVideoPod(sessionId, preferredDc);
     } finally {
       inFlightVideoProvisions.delete(sessionId);
     }
@@ -1487,6 +1503,7 @@ interface PlacementTarget {
 async function selectPlacement(
   sessionId: string,
   excludeDcs: ReadonlySet<string> = new Set(),
+  preferredDc?: string,
 ): Promise<PlacementTarget | null> {
   const volumes = config.NETWORK_VOLUMES_BY_DC;
   const volumeDcs = Object.keys(volumes).filter((dc) => !excludeDcs.has(dc));
@@ -1528,12 +1545,29 @@ async function selectPlacement(
     return br - ar;
   });
 
+  // Float the caller's preferred DC to the front IF it shows any non-zero
+  // stock. Used by video-pod placement to co-locate with the image pod's
+  // DC, avoiding cross-DC trigger latency and the "image pod placed in
+  // working DC X but video pod independently chose broken DC Y" trap.
+  if (preferredDc) {
+    const idx = probed.findIndex((p) => p.dc === preferredDc);
+    if (idx > 0) {
+      const candidate = probed[idx]!;
+      const stockRank = candidate.bid ? (rank[candidate.bid.stockStatus] ?? 0) : 0;
+      if (stockRank > 0) {
+        probed.splice(idx, 1);
+        probed.unshift(candidate);
+      }
+    }
+  }
+
   log.info(
     {
       sessionId,
       event: 'provision.placement.ranked',
       dcs: probed.map((p) => ({ dc: p.dc, stock: p.bid?.stockStatus ?? 'none' })),
       excluded: Array.from(excludeDcs),
+      preferredDc: preferredDc ?? null,
     },
     'DC placement ranked',
   );

--- a/backend/src/modules/orchestrator/orchestrator.ts
+++ b/backend/src/modules/orchestrator/orchestrator.ts
@@ -214,15 +214,18 @@ const MAX_CONCURRENT_PROVISIONS = Number(process.env['MAX_CONCURRENT_PROVISIONS'
 // Pod kinds: one operation (provision a pod) parameterized by a small static
 // config. POD_CONFIGS holds the six values that genuinely differ between
 // image and video pods. Everything else — DC selection, reroll on stall,
-// runtime+health waits, in-process inFlight dedup, idle reaping, reconcile —
-// is shared machinery in `_runProvisionLoop` / `_getOrProvisionPod` /
-// `_replacePodSession` (this file). Public per-kind exports (getOrProvisionPod,
-// getOrProvisionVideoPod, replaceSession, replaceVideoSession) are thin
-// wrappers expressing the per-kind contract differences (image: throws on
-// failure; video: returns null, best-effort).
+// runtime+health waits, idle reaping, reconcile — is shared machinery in
+// `_runProvisionLoop`. The four public entry points (getOrProvisionPod /
+// getOrProvisionVideoPod / replaceSession / replaceVideoSession) call the
+// helper with `kind` and read POD_CONFIGS[kind] for the diffs. Per-kind
+// outer concerns (image: semaphore + initial-row writeSession + Sentry span +
+// emitState; video: best-effort try/catch + image-DC co-location) live in
+// the public functions, not the helper.
 //
-// Adding a new pod kind = add a row to POD_CONFIGS + thin public wrappers.
-// No new architecture, no new Redis schema field, no new inFlight map.
+// One in-process inFlight map (`inFlightProvisions`, keyed `${kind}:${sessionId}`)
+// dedupes concurrent provisions for both kinds. Adding a new pod kind = add
+// a row to POD_CONFIGS + 1-2 thin public wrappers; no new Redis schema
+// field, no new map.
 // ────────────────────────────────────────────────────────────────────────────
 
 export type PodKind = 'image' | 'video';
@@ -291,11 +294,11 @@ interface RedisSession {
   createdAt: number;
   lastActivityAt: number;
   replacementCount: number;
-  // Best-effort video pod tracking. Set by setVideoPod() once
-  // provisionVideoPod resolves; cleared by clearVideoPod() on stream close
-  // or by the reaper. The image pod can serve without these — they only
-  // exist to (a) drive reconcile so we don't orphan video pods after
-  // crashes, and (b) let the reaper terminate both pods together.
+  // Best-effort video pod tracking. Stamped by POD_CONFIGS.video.stampRow
+  // on successful provision; cleared by clearVideoPod() on relay-wire
+  // failure or replacement. The image pod can serve without this — it
+  // exists only to (a) drive reconcile so we don't orphan video pods
+  // after crashes, and (b) let the reaper terminate both pods together.
   videoPodId: string | null;
 }
 
@@ -1636,7 +1639,7 @@ const POD_CONFIGS: Record<PodKind, PodKindConfig> = {
       if (pod && pod.desiredStatus === 'RUNNING' && pod.runtime !== null) {
         return {
           podId: row.videoPodId,
-          podUrl: `wss://${row.videoPodId}-8766.proxy.runpod.net/ws`,
+          podUrl: `wss://${row.videoPodId}-${POD_CONFIGS.video.port}.proxy.runpod.net/ws`,
         };
       }
       return null;

--- a/backend/src/modules/orchestrator/orchestrator.ts
+++ b/backend/src/modules/orchestrator/orchestrator.ts
@@ -1153,12 +1153,51 @@ async function provision(sessionId: string): Promise<ProvisionResult> {
 
 // ────────────────────────────────────────────────────────────────────────────
 // Video pod public entry points. Both call into the unified machinery
-// (`_runProvisionLoop` + `_replacePodSession` via POD_CONFIGS.video). The
-// only video-specific concerns here are: (a) best-effort contract — return
-// null on any failure, image session continues; (b) co-locate with image's
-// DC; (c) join concurrent in-flight provisions (covers a quick iPad
-// reconnect during the LTXV warmup window).
+// (`_runProvisionLoop` via POD_CONFIGS.video). The only video-specific
+// concerns here are: (a) best-effort contract — return null on any failure,
+// image session continues; (b) co-locate with image's DC; (c) join
+// concurrent in-flight provisions (covers a quick iPad reconnect during
+// the LTXV warmup window).
 // ────────────────────────────────────────────────────────────────────────────
+
+/** Read the image pod's current DC for co-location. Returns undefined if
+ *  no image pod yet or RunPod query fails. Both video entry points call
+ *  this so a video provision targets the same DC as image (avoids
+ *  cross-DC trigger latency + bad-DC landing). */
+async function _imagePodDc(session: RedisSession | null): Promise<string | undefined> {
+  if (!session?.podId) return undefined;
+  const pod = await getPod(session.podId).catch(() => null);
+  return pod?.machine?.dataCenterId ?? undefined;
+}
+
+/** Kick off (or reuse) a video provision in the inFlight map. Stores the
+ *  rich-shape promise from _runProvisionLoop, returns the narrower
+ *  best-effort {podId, podUrl}|null. Used by both fresh provision
+ *  (getOrProvisionVideoPod) and replacement (replaceVideoSession). */
+async function _runVideoProvision(
+  sessionId: string,
+  preferredDc: string | undefined,
+): Promise<{ podId: string; podUrl: string } | null> {
+  const key = `video:${sessionId}`;
+  const promise = (async () => {
+    try {
+      return await _runProvisionLoop('video', sessionId, { preferredDc });
+    } finally {
+      inFlightProvisions.delete(key);
+    }
+  })();
+  inFlightProvisions.set(key, promise);
+  try {
+    const r = await promise;
+    return { podId: r.podId, podUrl: r.podUrl };
+  } catch (err) {
+    log.warn(
+      { sessionId, err: (err as Error).message, pod_kind: 'video' },
+      'video provision failed; session is image-only',
+    );
+    return null;
+  }
+}
 
 /**
  * Get-or-provision the video pod for a session.
@@ -1176,7 +1215,7 @@ export async function getOrProvisionVideoPod(
 ): Promise<{ podId: string; podUrl: string } | null> {
   const existing = await readSession(sessionId);
 
-  // ── Reuse path ─────────────────────────────────────────────────────
+  // ── Reuse path: ready pod (RUNNING+runtime). ───────────────────────
   if (existing) {
     const reusable = await POD_CONFIGS.video.getReusableFromRow(existing);
     if (reusable) {
@@ -1186,37 +1225,16 @@ export async function getOrProvisionVideoPod(
       );
       return reusable;
     }
-    // Pod exists on row but isn't fully ready — could be mid-boot from a
-    // concurrent provision on this instance. If so, join its promise.
-    if (existing.videoPodId) {
-      const inFlight = inFlightProvisions.get(`video:${sessionId}`);
-      if (inFlight) {
-        log.info(
-          { sessionId, videoPodId: existing.videoPodId, pod_kind: 'video', event: '[provision/video] joined in-flight' },
-          '[provision/video] pod still booting; joining in-flight provision',
-        );
-        try {
-          const r = await inFlight;
-          return { podId: r.podId, podUrl: r.podUrl };
-        } catch {
-          return null;
-        }
-      }
-      // Stale id (pod gone or different replica owns it). Clear and reprovision.
-      log.info(
-        { sessionId, videoPodId: existing.videoPodId, pod_kind: 'video', event: '[provision/video] stale id' },
-        '[provision/video] stashed videoPodId is stale; reprovisioning',
-      );
-      await clearVideoPod(sessionId).catch(() => {});
-    }
   }
 
-  // ── In-flight join (no row stamp yet — concurrent fresh provision) ──
+  // ── In-flight join: another concurrent caller is already provisioning. ──
+  // (Catches both "row has videoPodId, mid-boot on this instance" and
+  // "no row stamp yet, but provision started microseconds ago".)
   const inFlight = inFlightProvisions.get(`video:${sessionId}`);
   if (inFlight) {
     log.info(
       { sessionId, pod_kind: 'video', event: '[provision/video] joined in-flight' },
-      '[provision/video] joining in-flight provision (no row stamp yet)',
+      '[provision/video] joining in-flight provision',
     );
     try {
       const r = await inFlight;
@@ -1226,38 +1244,17 @@ export async function getOrProvisionVideoPod(
     }
   }
 
-  // ── Fresh provision ────────────────────────────────────────────────
-  // Co-locate with the image pod's DC: avoids cross-DC trigger latency
-  // and avoids landing the video pod in a DC that's currently broken
-  // (e.g. US-NC-1 host issues we've seen) when the image pod is already
-  // running fine elsewhere.
-  let preferredDc: string | undefined;
-  if (existing?.podId) {
-    const imagePod = await getPod(existing.podId).catch(() => null);
-    if (imagePod?.machine?.dataCenterId) {
-      preferredDc = imagePod.machine.dataCenterId;
-    }
+  // ── Stale row stamp: pod gone or owned by a different replica. ────
+  if (existing?.videoPodId) {
+    log.info(
+      { sessionId, videoPodId: existing.videoPodId, pod_kind: 'video', event: '[provision/video] stale id' },
+      '[provision/video] stashed videoPodId is stale; reprovisioning',
+    );
+    await clearVideoPod(sessionId).catch(() => {});
   }
 
-  const key = `video:${sessionId}`;
-  const promise = (async () => {
-    try {
-      return await _runProvisionLoop('video', sessionId, { preferredDc });
-    } finally {
-      inFlightProvisions.delete(key);
-    }
-  })();
-  inFlightProvisions.set(key, promise);
-  try {
-    const r = await promise;
-    return { podId: r.podId, podUrl: r.podUrl };
-  } catch (err) {
-    log.warn(
-      { sessionId, err: (err as Error).message, pod_kind: 'video', event: '[provision/video] failed' },
-      '[provision/video] provision failed; image session continues image-only',
-    );
-    return null;
-  }
+  // ── Fresh provision. ──────────────────────────────────────────────
+  return _runVideoProvision(sessionId, await _imagePodDc(existing));
 }
 
 /**
@@ -1268,8 +1265,9 @@ export async function getOrProvisionVideoPod(
  * same-pod reconnect attempt fails (i.e., the pod is truly gone, not
  * just a transient WS drop).
  *
- * Best-effort contract: returns null on any failure. Caller falls back
- * to image-only.
+ * Best-effort contract: returns null on any failure. No `replacementCount`
+ * bump — that budget is for image (where exhaustion bounces the iPad);
+ * video replacement just falls back to image-only on giveup.
  */
 export async function replaceVideoSession(
   sessionId: string,
@@ -1279,50 +1277,23 @@ export async function replaceVideoSession(
     log.warn({ sessionId }, 'replaceVideoSession: no session to replace');
     return null;
   }
-  const oldPodId = session.videoPodId;
-  log.info({ sessionId, oldPodId, pod_kind: 'video' }, 'Starting video session replacement');
+  log.info(
+    { sessionId, oldPodId: session.videoPodId, pod_kind: 'video' },
+    'Starting video session replacement',
+  );
 
-  // Clear old pod ref + terminate (fire-and-forget). No replacement-count
-  // bump — we share session.replacementCount with image, and video failures
-  // are recoverable enough that we don't want to consume the budget.
+  // Clear old pod ref + terminate (fire-and-forget).
   await clearVideoPod(sessionId).catch(() => {});
-  if (oldPodId) {
-    terminatePod(oldPodId).catch((e) =>
+  if (session.videoPodId) {
+    terminatePod(session.videoPodId).catch((e) =>
       log.warn(
-        { sessionId, oldPodId, err: (e as Error).message },
+        { sessionId, oldPodId: session.videoPodId, err: (e as Error).message },
         'replaceVideoSession: terminate old pod failed (reaper will clean)',
       ),
     );
   }
 
-  // Co-locate the replacement with image pod's current DC.
-  let preferredDc: string | undefined;
-  if (session.podId) {
-    const imagePod = await getPod(session.podId).catch(() => null);
-    if (imagePod?.machine?.dataCenterId) {
-      preferredDc = imagePod.machine.dataCenterId;
-    }
-  }
-
-  const key = `video:${sessionId}`;
-  const promise = (async () => {
-    try {
-      return await _runProvisionLoop('video', sessionId, { preferredDc });
-    } finally {
-      inFlightProvisions.delete(key);
-    }
-  })();
-  inFlightProvisions.set(key, promise);
-  try {
-    const r = await promise;
-    return { podId: r.podId, podUrl: r.podUrl };
-  } catch (err) {
-    log.warn(
-      { sessionId, err: (err as Error).message, pod_kind: 'video' },
-      'replaceVideoSession failed; session is image-only',
-    );
-    return null;
-  }
+  return _runVideoProvision(sessionId, await _imagePodDc(session));
 }
 
 /** Terminate a video pod by ID. Never throws. Used by stream.ts on relay
@@ -1607,7 +1578,10 @@ const POD_CONFIGS: Record<PodKind, PodKindConfig> = {
   image: {
     namePrefix: POD_PREFIX,
     bootDockerArgs: BOOT_DOCKER_ARGS,
-    port: 8765,
+    // Both image (server.py) and video (video_server.py) bind to 8766 via
+    // BOOT_ENV.FLUX_PORT — same Python server framework, different scripts.
+    // Kept parametric in case a future pod kind diverges.
+    port: 8766,
     stallMs: config.POD_BOOT_WATCHDOG_ENABLED ? config.POD_BOOT_STALL_MS : Infinity,
     createPodForDc: (target, sessionId) => {
       const podName = `${POD_PREFIX}${sessionId.slice(0, 16)}`;

--- a/backend/src/modules/orchestrator/orchestrator.ts
+++ b/backend/src/modules/orchestrator/orchestrator.ts
@@ -1282,7 +1282,7 @@ export async function provisionVideoPod(
       cloudType: 'SECURE',
       dockerArgs: BOOT_DOCKER_ARGS_VIDEO,
       env: BOOT_ENV,
-      containerRegistryAuthId: config.RUNPOD_REGISTRY_AUTH_ID || undefined,
+      containerRegistryAuthId: config.RUNPOD_REGISTRY_AUTH_ID,
       ...dcField,
       ...volField,
     });
@@ -1571,7 +1571,7 @@ async function createPodWithFallback(
         bidPerGpu: bid,
         dockerArgs: BOOT_DOCKER_ARGS,
         env: BOOT_ENV,
-        containerRegistryAuthId: config.RUNPOD_REGISTRY_AUTH_ID || undefined,
+        containerRegistryAuthId: config.RUNPOD_REGISTRY_AUTH_ID,
         ...dcField,
         ...volField,
       });
@@ -1623,7 +1623,7 @@ async function createPodWithFallback(
       cloudType: 'SECURE',
       dockerArgs: BOOT_DOCKER_ARGS,
       env: BOOT_ENV,
-      containerRegistryAuthId: config.RUNPOD_REGISTRY_AUTH_ID || undefined,
+      containerRegistryAuthId: config.RUNPOD_REGISTRY_AUTH_ID,
       ...dcField,
       ...volField,
     });

--- a/backend/src/modules/orchestrator/orchestrator.ts
+++ b/backend/src/modules/orchestrator/orchestrator.ts
@@ -183,6 +183,14 @@ const BASE_IMAGE = 'runpod/pytorch:1.0.3-cu1281-torch291-ubuntu2404';
 // so SIGTERM reaches uvicorn directly.
 const BOOT_DOCKER_ARGS =
   "bash -lc 'source /workspace/venv/bin/activate && cd /workspace/app && exec python3 -u server.py'";
+// Video pod runs LTXV i2v on a separate pod (see flux-klein-server/video_server.py).
+// Same volume / venv / port as the image pod — only the entry script differs.
+const BOOT_DOCKER_ARGS_VIDEO =
+  "bash -lc 'source /workspace/venv/bin/activate && cd /workspace/app && exec python3 -u video_server.py'";
+// Pod name prefix for video pods. Distinct from POD_PREFIX so reconcile
+// can list them separately and so RunPod console / Discord alerts are
+// unambiguous about which kind died.
+const VIDEO_POD_PREFIX = 'kiki-vsession-';
 const BOOT_ENV: Array<{ key: string; value: string }> = [
   { key: 'HF_HOME', value: '/workspace/huggingface' },
   { key: 'HF_HUB_OFFLINE', value: '1' },
@@ -217,6 +225,12 @@ interface RedisSession {
   createdAt: number;
   lastActivityAt: number;
   replacementCount: number;
+  // Best-effort video pod tracking. Set by setVideoPod() once
+  // provisionVideoPod resolves; cleared by clearVideoPod() on stream close
+  // or by the reaper. The image pod can serve without these — they only
+  // exist to (a) drive reconcile so we don't orphan video pods after
+  // crashes, and (b) let the reaper terminate both pods together.
+  videoPodId: string | null;
 }
 
 const IDLE_TTL_SECONDS = Math.ceil(IDLE_TIMEOUT_MS / 1000) + IDLE_GRACE_SECONDS;
@@ -243,6 +257,7 @@ async function readSession(sessionId: string): Promise<RedisSession | null> {
     createdAt: Number(data['createdAt'] ?? 0),
     lastActivityAt: Number(data['lastActivityAt'] ?? 0),
     replacementCount: Number(data['replacementCount'] ?? 0),
+    videoPodId: data['videoPodId'] || null,
   };
 }
 
@@ -275,7 +290,7 @@ async function patchSession(
   sessionId: string,
   patch: Partial<Pick<
     RedisSession,
-    'state' | 'stateEnteredAt' | 'failureCategory' | 'podId' | 'podUrl' | 'podType' | 'lastActivityAt' | 'replacementCount'
+    'state' | 'stateEnteredAt' | 'failureCategory' | 'podId' | 'podUrl' | 'podType' | 'lastActivityAt' | 'replacementCount' | 'videoPodId'
   >>,
 ): Promise<void> {
   const key = sessionKey(sessionId);
@@ -288,6 +303,7 @@ async function patchSession(
   if (patch.podType !== undefined) fields['podType'] = patch.podType ?? '';
   if (patch.lastActivityAt !== undefined) fields['lastActivityAt'] = String(patch.lastActivityAt);
   if (patch.replacementCount !== undefined) fields['replacementCount'] = String(patch.replacementCount);
+  if (patch.videoPodId !== undefined) fields['videoPodId'] = patch.videoPodId ?? '';
   if (Object.keys(fields).length === 0) return;
   await getRedis().multi()
     .hset(key, fields)
@@ -450,6 +466,11 @@ export async function abortSession(
         log.warn({ sessionId, podId: session.podId, err: (err as Error).message }, 'abortSession: terminatePod failed'),
       );
     }
+    if (session?.videoPodId) {
+      terminatePod(session.videoPodId).catch((err) =>
+        log.warn({ sessionId, videoPodId: session.videoPodId, err: (err as Error).message }, 'abortSession: terminate video pod failed'),
+      );
+    }
     await deleteSession(sessionId);
   } catch (err) {
     log.warn({ sessionId, err: (err as Error).message }, 'abortSession failed');
@@ -509,6 +530,7 @@ export async function getOrProvisionPod(sessionId: string): Promise<{ podUrl: st
     createdAt: now,
     lastActivityAt: now,
     replacementCount: 0,
+    videoPodId: null,
   });
 
   let provisionedPodId: string | null = null;
@@ -768,9 +790,10 @@ async function runReaper(): Promise<void> {
 
       const podId = data['podId']!;
       const sessionId = data['sessionId']!;
+      const videoPodId = data['videoPodId'] || null;
       const createdAt = Number(data['createdAt'] ?? 0);
       const lifetimeMs = createdAt > 0 ? now - createdAt : 0;
-      log.info({ sessionId, podId, idleMs, lifetimeMs }, 'Reaping idle pod');
+      log.info({ sessionId, podId, videoPodId, idleMs, lifetimeMs, kind: 'image' }, '[reaper] terminating session=' + sessionId + ' kind=image');
       trackPodTerminated({ userId: sessionId, reason: 'idle', lifetimeMs });
       notifyPodTerminated(podId, `idle ${Math.round(idleMs / 1000)}s`);
       // Emit through the broker so the iPad sees state='terminated' with
@@ -783,6 +806,12 @@ async function runReaper(): Promise<void> {
       terminatePod(podId)
         .then(() => redis.del(key))
         .catch((err) => log.error({ sessionId, podId, err }, 'Reap failed'));
+      if (videoPodId) {
+        log.info({ sessionId, videoPodId, kind: 'video' }, '[reaper] terminating session=' + sessionId + ' kind=video');
+        terminatePod(videoPodId).catch((err) =>
+          log.error({ sessionId, videoPodId, err }, 'Reap video pod failed'),
+        );
+      }
     } catch (err) {
       log.warn({ key, err: (err as Error).message }, 'Reaper error on key');
     }
@@ -804,6 +833,7 @@ async function reconcileOrphanPods(minAgeSec = 0): Promise<void> {
     // 1. Read all session keys from Redis
     const redis = getRedis();
     const sessionPodIds = new Set<string>();
+    const sessionVideoPodIds = new Set<string>();
     const staleKeys: string[] = [];
     for await (const key of eachSessionKey()) {
       const data = await redis.hgetall(key);
@@ -818,6 +848,14 @@ async function reconcileOrphanPods(minAgeSec = 0): Promise<void> {
         // treat as stale and clean up.
         staleKeys.push(key);
       }
+      // Video pods: in use whenever a session row references them, regardless
+      // of the image pod's state — the video provision happens after image
+      // 'ready', so the row's state is always 'ready' by the time videoPodId
+      // is set. But guard with the same `state === 'ready'` filter to avoid
+      // adopting a videoPodId from a row that's mid-cleanup.
+      if (data['videoPodId'] && state === 'ready') {
+        sessionVideoPodIds.add(data['videoPodId']);
+      }
     }
 
     // Clean up stale in-progress rows
@@ -826,10 +864,11 @@ async function reconcileOrphanPods(minAgeSec = 0): Promise<void> {
       await redis.del(key);
     }
 
-    // 2. List RunPod pods
+    // 2. List RunPod pods (image + video, separately so we count distinctly).
     const pods = await listPodsByPrefix(POD_PREFIX);
+    const videoPods = await listPodsByPrefix(VIDEO_POD_PREFIX);
 
-    // 3. Adopt, skip young, or terminate
+    // 3. Adopt, skip young, or terminate (image pods)
     let adopted = 0;
     let skippedYoung = 0;
     let terminated = 0;
@@ -854,17 +893,65 @@ async function reconcileOrphanPods(minAgeSec = 0): Promise<void> {
       );
     }
 
+    // 3b. Same logic for video pods. Source of truth: videoPodId fields on
+    // Redis session rows. Anything else under the kiki-vsession-* prefix is
+    // an orphan (backend crash mid-stream, or stream.ts close handler missed
+    // the terminate). Boot reconcile (minAgeSec=0) is aggressive — there
+    // are no live sessions yet — and periodic respects skip-young.
+    let videoAdopted = 0;
+    let videoSkippedYoung = 0;
+    let videoTerminated = 0;
+    for (const pod of videoPods) {
+      if (sessionVideoPodIds.has(pod.id)) {
+        videoAdopted++;
+        continue;
+      }
+      if (minAgeSec > 0) {
+        const uptime = pod.runtime?.uptimeInSeconds ?? 0;
+        if (pod.runtime === null || uptime < minAgeSec) {
+          videoSkippedYoung++;
+          continue;
+        }
+      }
+      log.warn({ podId: pod.id, name: pod.name, kind: 'video' }, '[reconcile] orphans found terminating video pod');
+      videoTerminated++;
+      await terminatePod(pod.id).catch((err) =>
+        log.error({ podId: pod.id, name: pod.name, err }, 'Failed to terminate orphan video pod'),
+      );
+    }
+
     // 4. Clean up Redis sessions whose pods no longer exist on RunPod
     const runpodPodIds = new Set(pods.map((p) => p.id));
+    const runpodVideoPodIds = new Set(videoPods.map((p) => p.id));
     for await (const key of eachSessionKey()) {
       const podId = await redis.hget(key, 'podId');
       if (podId && !runpodPodIds.has(podId)) {
         log.warn({ key, podId }, 'Reconcile: deleting session for pod no longer on RunPod');
         await redis.del(key);
+        continue;
+      }
+      // Image pod still exists; clear stale videoPodId if the video pod is gone.
+      const stashedVideoPodId = await redis.hget(key, 'videoPodId');
+      if (stashedVideoPodId && !runpodVideoPodIds.has(stashedVideoPodId)) {
+        log.warn(
+          { key, videoPodId: stashedVideoPodId },
+          'Reconcile: clearing stale videoPodId on session (video pod gone)',
+        );
+        await redis.hdel(key, 'videoPodId');
       }
     }
 
-    log.info({ adopted, terminated, skippedYoung, staleProvisioning: staleKeys.length, minAgeSec }, 'Reconcile complete');
+    log.info(
+      {
+        adopted, terminated, skippedYoung, staleProvisioning: staleKeys.length,
+        videoAdopted, videoTerminated, videoSkippedYoung,
+        minAgeSec,
+        event: '[reconcile] orphans found',
+        image: pods.length,
+        video: videoPods.length,
+      },
+      'Reconcile complete',
+    );
   } catch (err) {
     log.error({ err }, 'Reconcile failed (continuing anyway)');
   }
@@ -1139,6 +1226,144 @@ async function provision(sessionId: string): Promise<ProvisionResult> {
       throw new Error('provision: reroll loop exited without resolution');
     },
   );
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// Video pod (best-effort, on-demand only, no replacement)
+// ────────────────────────────────────────────────────────────────────────────
+//
+// Lifecycle and tracking decisions:
+//   - One video pod per session, provisioned by stream.ts AFTER the image pod
+//     resolves 'ready' (so the user's image flow is unblocked while video
+//     warms up).
+//   - Best-effort: if creation/health fails, log + warn and return null.
+//     Image gen continues normally; the iPad sees no error.
+//   - Tracked via `videoPodId` on the existing session row (no separate
+//     Redis key) so the reaper terminates both pods together when image is
+//     idle-reaped, and reconcile can match orphans against active sessions.
+//   - On-demand only for v1. Spot would help cost but adds replacement
+//     complexity that's not justified for a feature whose worst-case
+//     degradation is "no video animation this session".
+
+export async function provisionVideoPod(
+  sessionId: string,
+): Promise<{ podId: string; podUrl: string } | null> {
+  const t0 = Date.now();
+  let target: PlacementTarget | null;
+  try {
+    target = await selectPlacement(sessionId);
+  } catch (err) {
+    log.warn(
+      { sessionId, err: (err as Error).message, event: '[provision/video] selectPlacement failed' },
+      '[provision/video] selectPlacement threw',
+    );
+    return null;
+  }
+  if (!target) {
+    log.warn({ sessionId, event: '[provision/video] no DC capacity' }, '[provision/video] no DC capacity for video pod');
+    return null;
+  }
+
+  const podName = `${VIDEO_POD_PREFIX}${sessionId.slice(0, 16)}`;
+  const dcField = target.dataCenterId ? { dataCenterId: target.dataCenterId } : {};
+  const volField = target.networkVolumeId ? { networkVolumeId: target.networkVolumeId } : {};
+
+  log.info(
+    { sessionId, dc: target.dataCenterId, pod_kind: 'video', event: '[provision/video] start' },
+    '[provision/video] creating on-demand pod',
+  );
+
+  let podId: string;
+  try {
+    const result = await createOnDemandPod({
+      name: podName,
+      imageName: BASE_IMAGE,
+      gpuTypeId: GPU_TYPE_ID,
+      cloudType: 'SECURE',
+      dockerArgs: BOOT_DOCKER_ARGS_VIDEO,
+      env: BOOT_ENV,
+      ...dcField,
+      ...volField,
+    });
+    podId = result.id;
+    log.info(
+      { sessionId, podId, costPerHr: result.costPerHr, pod_kind: 'video', event: '[provision/video] created' },
+      '[provision/video] pod created',
+    );
+  } catch (err) {
+    log.warn(
+      { sessionId, err: (err as Error).message, pod_kind: 'video', event: '[provision/video] create failed' },
+      '[provision/video] createOnDemandPod failed',
+    );
+    Sentry.addBreadcrumb({
+      category: 'provision/video',
+      level: 'warning',
+      message: 'Video pod create failed',
+      data: { sessionId, err: (err as Error).message },
+    });
+    return null;
+  }
+
+  try {
+    await waitForRuntime(podId);
+    const healthUrl = `https://${podId}-8766.proxy.runpod.net/health`;
+    await waitForHealth(podId, healthUrl);
+    const podUrl = `wss://${podId}-8766.proxy.runpod.net/ws`;
+    log.info(
+      { sessionId, podId, podUrl, totalMs: Date.now() - t0, pod_kind: 'video', event: '[provision/video] ready' },
+      '[provision/video] pod ready',
+    );
+    return { podId, podUrl };
+  } catch (err) {
+    log.warn(
+      { sessionId, podId, err: (err as Error).message, pod_kind: 'video', event: '[provision/video] runtime/health failed' },
+      '[provision/video] failed runtime/health; terminating pod',
+    );
+    terminatePod(podId).catch((e) =>
+      log.warn({ podId, err: (e as Error).message }, '[provision/video] terminate-after-fail failed'),
+    );
+    return null;
+  }
+}
+
+/** Terminate a video pod by ID. Never throws. */
+export async function terminateVideoPod(podId: string): Promise<void> {
+  try {
+    await terminatePod(podId);
+    log.info({ podId, pod_kind: 'video', event: '[provision/video] terminated' }, '[provision/video] terminated');
+  } catch (err) {
+    log.warn(
+      { podId, err: (err as Error).message, pod_kind: 'video' },
+      '[provision/video] terminate failed (will be cleaned by reconcile)',
+    );
+  }
+}
+
+/** Stash the just-provisioned video pod ID on the session row so reaper +
+ *  reconcile can find it. Best-effort: if the session row doesn't exist
+ *  (somehow already cleaned up), silently skip — the reconciler will
+ *  terminate this pod as an orphan within a minute. */
+export async function setVideoPod(sessionId: string, videoPodId: string): Promise<void> {
+  try {
+    await patchSession(sessionId, { videoPodId });
+  } catch (err) {
+    log.warn(
+      { sessionId, videoPodId, err: (err as Error).message },
+      'setVideoPod patchSession failed (orphan will be reconciled)',
+    );
+  }
+}
+
+/** Clear videoPodId on session row (e.g. after stream close). Never throws. */
+export async function clearVideoPod(sessionId: string): Promise<void> {
+  try {
+    await patchSession(sessionId, { videoPodId: null });
+  } catch (err) {
+    log.warn(
+      { sessionId, err: (err as Error).message },
+      'clearVideoPod patchSession failed',
+    );
+  }
 }
 
 /**

--- a/backend/src/modules/orchestrator/orchestrator.ts
+++ b/backend/src/modules/orchestrator/orchestrator.ts
@@ -1282,6 +1282,7 @@ export async function provisionVideoPod(
       cloudType: 'SECURE',
       dockerArgs: BOOT_DOCKER_ARGS_VIDEO,
       env: BOOT_ENV,
+      containerRegistryAuthId: config.RUNPOD_REGISTRY_AUTH_ID || undefined,
       ...dcField,
       ...volField,
     });
@@ -1570,6 +1571,7 @@ async function createPodWithFallback(
         bidPerGpu: bid,
         dockerArgs: BOOT_DOCKER_ARGS,
         env: BOOT_ENV,
+        containerRegistryAuthId: config.RUNPOD_REGISTRY_AUTH_ID || undefined,
         ...dcField,
         ...volField,
       });
@@ -1621,6 +1623,7 @@ async function createPodWithFallback(
       cloudType: 'SECURE',
       dockerArgs: BOOT_DOCKER_ARGS,
       env: BOOT_ENV,
+      containerRegistryAuthId: config.RUNPOD_REGISTRY_AUTH_ID || undefined,
       ...dcField,
       ...volField,
     });

--- a/backend/src/modules/orchestrator/orchestrator.ts
+++ b/backend/src/modules/orchestrator/orchestrator.ts
@@ -161,11 +161,14 @@ export type PodType = 'spot' | 'onDemand';
 
 // Session registry lives in Redis (WS5). Local map only holds in-flight
 // provision promises for same-process join (Promises can't be serialized).
-const inFlightProvisions = new Map<string, Promise<{ podUrl: string }>>();
-// Same idea for video pods. Closes the in-process race where a quick
-// iPad reconnect during a video pod's boot would otherwise trigger a
-// second provision before the first one's videoPodId is on the row.
-const inFlightVideoProvisions = new Map<string, Promise<{ podId: string; podUrl: string } | null>>();
+// Keyed by `${kind}:${sessionId}` so image and video pods don't collide.
+// Value is the rich shape from _runProvisionLoop; per-kind public wrappers
+// project this onto their narrower contract (image: {podUrl}; video:
+// {podId, podUrl}).
+const inFlightProvisions = new Map<
+  string,
+  Promise<{ podId: string; podUrl: string; podType: PodType; dc: string | null }>
+>();
 
 const SESSION_PREFIX = 'session:';
 const POD_PREFIX = 'kiki-session-';
@@ -558,18 +561,20 @@ export async function getOrProvisionPod(sessionId: string): Promise<{ podUrl: st
   // 1. Check Redis for existing session
   const existing = await readSession(sessionId);
 
-  if (existing?.state === 'ready' && existing.podUrl) {
-    log.info({ sessionId, podId: existing.podId }, 'Reusing existing session pod');
-    return { podUrl: existing.podUrl };
+  const reusable = existing ? await POD_CONFIGS.image.getReusableFromRow(existing) : null;
+  if (reusable) {
+    log.info({ sessionId, podId: reusable.podId }, 'Reusing existing session pod');
+    return { podUrl: reusable.podUrl };
   }
 
   // 2. Check local in-flight map (same-process concurrent callers — fresh
   // provision OR replacement). Joiners subscribe via broker; here we just
   // await the same promise.
-  const inFlight = inFlightProvisions.get(sessionId);
+  const key = `image:${sessionId}`;
+  const inFlight = inFlightProvisions.get(key);
   if (inFlight) {
     log.info({ sessionId }, 'Joining in-flight provision');
-    return inFlight;
+    return inFlight.then((r) => ({ podUrl: r.podUrl }));
   }
 
   // 3. If Redis has a non-ready session but we don't own the promise
@@ -606,7 +611,7 @@ export async function getOrProvisionPod(sessionId: string): Promise<{ podUrl: st
         await emitState(sessionId, 'finding_gpu');
         const result = await provision(sessionId);
         provisionedPodId = result.podId;
-        return { podUrl: result.podUrl };
+        return { podId: result.podId, podUrl: result.podUrl, podType: result.podType, dc: null };
       } finally {
         releaseSemaphore();
       }
@@ -625,12 +630,12 @@ export async function getOrProvisionPod(sessionId: string): Promise<{ podUrl: st
       await deleteSession(sessionId).catch(() => {});
       throw err;
     } finally {
-      inFlightProvisions.delete(sessionId);
+      inFlightProvisions.delete(key);
     }
   })();
 
-  inFlightProvisions.set(sessionId, promise);
-  return promise;
+  inFlightProvisions.set(key, promise);
+  return promise.then((r) => ({ podUrl: r.podUrl }));
 }
 
 export function touch(sessionId: string): void {
@@ -709,6 +714,7 @@ export async function replaceSession(sessionId: string): Promise<{ podUrl: strin
 
   const t0 = Date.now();
   let newPodId: string | null = null;
+  const key = `image:${sessionId}`;
   const replacementPromise = (async () => {
     try {
       if (isSemaphoreFull()) await emitState(sessionId, 'queued');
@@ -719,7 +725,7 @@ export async function replaceSession(sessionId: string): Promise<{ podUrl: strin
         newPodId = result.podId;
         const replacementMs = Date.now() - t0;
         log.info({ sessionId, oldPodId, newPodId: result.podId, replacementMs, attempt }, 'Session replaced');
-        return { podUrl: result.podUrl };
+        return { podId: result.podId, podUrl: result.podUrl, podType: result.podType, dc: null };
       } finally {
         releaseSemaphore();
       }
@@ -747,14 +753,14 @@ export async function replaceSession(sessionId: string): Promise<{ podUrl: strin
       });
       throw err;
     } finally {
-      inFlightProvisions.delete(sessionId);
+      inFlightProvisions.delete(key);
     }
   })();
 
   // Register in inFlight so concurrent getOrProvisionPod calls join this
   // replacement instead of starting a duplicate.
-  inFlightProvisions.set(sessionId, replacementPromise);
-  return replacementPromise;
+  inFlightProvisions.set(key, replacementPromise);
+  return replacementPromise.then((r) => ({ podUrl: r.podUrl }));
 }
 
 export function sessionClosed(sessionId: string): void {
@@ -1146,120 +1152,181 @@ async function provision(sessionId: string): Promise<ProvisionResult> {
 }
 
 // ────────────────────────────────────────────────────────────────────────────
-// Video pod (best-effort, on-demand only, no replacement)
+// Video pod public entry points. Both call into the unified machinery
+// (`_runProvisionLoop` + `_replacePodSession` via POD_CONFIGS.video). The
+// only video-specific concerns here are: (a) best-effort contract — return
+// null on any failure, image session continues; (b) co-locate with image's
+// DC; (c) join concurrent in-flight provisions (covers a quick iPad
+// reconnect during the LTXV warmup window).
 // ────────────────────────────────────────────────────────────────────────────
-//
-// Lifecycle and tracking decisions:
-//   - One video pod per session, provisioned by stream.ts AFTER the image pod
-//     resolves 'ready' (so the user's image flow is unblocked while video
-//     warms up).
-//   - Best-effort: if creation/health fails, log + warn and return null.
-//     Image gen continues normally; the iPad sees no error.
-//   - Tracked via `videoPodId` on the existing session row (no separate
-//     Redis key) so the reaper terminates both pods together when image is
-//     idle-reaped, and reconcile can match orphans against active sessions.
-//   - On-demand only for v1. Spot would help cost but adds replacement
-//     complexity that's not justified for a feature whose worst-case
-//     degradation is "no video animation this session".
 
-export async function provisionVideoPod(
+/**
+ * Get-or-provision the video pod for a session.
+ *
+ * Returns null on failure (best-effort — image session keeps going). On
+ * success returns { podId, podUrl } for stream.ts to wire its relay.
+ *
+ * Reuse path: probes RunPod via POD_CONFIGS.video.getReusableFromRow.
+ * If pod is RUNNING+runtime, reuse. If RUNNING-but-still-booting AND we
+ * own the in-flight promise, join it. Otherwise (gone, mid-boot on a
+ * different replica, or no prior pod) fall through to a fresh provision.
+ */
+export async function getOrProvisionVideoPod(
   sessionId: string,
-  preferredDc?: string,
 ): Promise<{ podId: string; podUrl: string } | null> {
-  const t0 = Date.now();
-  let target: PlacementTarget | null;
-  try {
-    target = await selectPlacement(sessionId, undefined, preferredDc);
-  } catch (err) {
-    log.warn(
-      { sessionId, err: (err as Error).message, event: '[provision/video] selectPlacement failed' },
-      '[provision/video] selectPlacement threw',
-    );
-    return null;
+  const existing = await readSession(sessionId);
+
+  // ── Reuse path ─────────────────────────────────────────────────────
+  if (existing) {
+    const reusable = await POD_CONFIGS.video.getReusableFromRow(existing);
+    if (reusable) {
+      log.info(
+        { sessionId, videoPodId: reusable.podId, pod_kind: 'video', event: '[provision/video] reused' },
+        '[provision/video] reusing existing pod (no cold start)',
+      );
+      return reusable;
+    }
+    // Pod exists on row but isn't fully ready — could be mid-boot from a
+    // concurrent provision on this instance. If so, join its promise.
+    if (existing.videoPodId) {
+      const inFlight = inFlightProvisions.get(`video:${sessionId}`);
+      if (inFlight) {
+        log.info(
+          { sessionId, videoPodId: existing.videoPodId, pod_kind: 'video', event: '[provision/video] joined in-flight' },
+          '[provision/video] pod still booting; joining in-flight provision',
+        );
+        try {
+          const r = await inFlight;
+          return { podId: r.podId, podUrl: r.podUrl };
+        } catch {
+          return null;
+        }
+      }
+      // Stale id (pod gone or different replica owns it). Clear and reprovision.
+      log.info(
+        { sessionId, videoPodId: existing.videoPodId, pod_kind: 'video', event: '[provision/video] stale id' },
+        '[provision/video] stashed videoPodId is stale; reprovisioning',
+      );
+      await clearVideoPod(sessionId).catch(() => {});
+    }
   }
-  if (!target) {
-    log.warn({ sessionId, event: '[provision/video] no DC capacity' }, '[provision/video] no DC capacity for video pod');
-    return null;
-  }
 
-  const podName = `${VIDEO_POD_PREFIX}${sessionId.slice(0, 16)}`;
-  const dcField = target.dataCenterId ? { dataCenterId: target.dataCenterId } : {};
-  const volField = target.networkVolumeId ? { networkVolumeId: target.networkVolumeId } : {};
-
-  log.info(
-    { sessionId, dc: target.dataCenterId, pod_kind: 'video', event: '[provision/video] start' },
-    '[provision/video] creating on-demand pod',
-  );
-
-  let podId: string;
-  try {
-    const result = await createOnDemandPod({
-      name: podName,
-      imageName: BASE_IMAGE,
-      gpuTypeId: GPU_TYPE_ID,
-      cloudType: 'SECURE',
-      dockerArgs: BOOT_DOCKER_ARGS_VIDEO,
-      env: BOOT_ENV,
-      containerRegistryAuthId: config.RUNPOD_REGISTRY_AUTH_ID,
-      ...dcField,
-      ...volField,
-    });
-    podId = result.id;
+  // ── In-flight join (no row stamp yet — concurrent fresh provision) ──
+  const inFlight = inFlightProvisions.get(`video:${sessionId}`);
+  if (inFlight) {
     log.info(
-      { sessionId, podId, costPerHr: result.costPerHr, pod_kind: 'video', event: '[provision/video] created' },
-      '[provision/video] pod created',
+      { sessionId, pod_kind: 'video', event: '[provision/video] joined in-flight' },
+      '[provision/video] joining in-flight provision (no row stamp yet)',
     );
-  } catch (err) {
-    log.warn(
-      { sessionId, err: (err as Error).message, pod_kind: 'video', event: '[provision/video] create failed' },
-      '[provision/video] createOnDemandPod failed',
-    );
-    Sentry.addBreadcrumb({
-      category: 'provision/video',
-      level: 'warning',
-      message: 'Video pod create failed',
-      data: { sessionId, err: (err as Error).message },
-    });
-    return null;
+    try {
+      const r = await inFlight;
+      return { podId: r.podId, podUrl: r.podUrl };
+    } catch {
+      return null;
+    }
   }
 
-  // Stamp videoPodId on the session row immediately, before waiting for
-  // boot. Otherwise a quick iPad reconnect during the 60-180s boot window
-  // hits getOrProvisionVideoPod with a row whose videoPodId is still null,
-  // and starts a SECOND pod — both then race the stall watchdog and both
-  // get terminated. Stamping here closes that window.
-  await setVideoPod(sessionId, podId);
+  // ── Fresh provision ────────────────────────────────────────────────
+  // Co-locate with the image pod's DC: avoids cross-DC trigger latency
+  // and avoids landing the video pod in a DC that's currently broken
+  // (e.g. US-NC-1 host issues we've seen) when the image pod is already
+  // running fine elsewhere.
+  let preferredDc: string | undefined;
+  if (existing?.podId) {
+    const imagePod = await getPod(existing.podId).catch(() => null);
+    if (imagePod?.machine?.dataCenterId) {
+      preferredDc = imagePod.machine.dataCenterId;
+    }
+  }
 
+  const key = `video:${sessionId}`;
+  const promise = (async () => {
+    try {
+      return await _runProvisionLoop('video', sessionId, { preferredDc });
+    } finally {
+      inFlightProvisions.delete(key);
+    }
+  })();
+  inFlightProvisions.set(key, promise);
   try {
-    // Bump stallMs to 180s for video pods. Default 45s isn't enough for
-    // a cold image pull on a fresh host, and unlike the image-pod path
-    // we don't reroll DCs on stall — a single stall = no video for this
-    // session. 180s comfortably covers a slow Docker Hub pull.
-    await waitForRuntime(podId, { stallMs: 180_000 });
-    const healthUrl = `https://${podId}-8766.proxy.runpod.net/health`;
-    await waitForHealth(podId, healthUrl);
-    const podUrl = `wss://${podId}-8766.proxy.runpod.net/ws`;
-    log.info(
-      { sessionId, podId, podUrl, totalMs: Date.now() - t0, pod_kind: 'video', event: '[provision/video] ready' },
-      '[provision/video] pod ready',
-    );
-    return { podId, podUrl };
+    const r = await promise;
+    return { podId: r.podId, podUrl: r.podUrl };
   } catch (err) {
     log.warn(
-      { sessionId, podId, err: (err as Error).message, pod_kind: 'video', event: '[provision/video] runtime/health failed' },
-      '[provision/video] failed runtime/health; terminating pod',
+      { sessionId, err: (err as Error).message, pod_kind: 'video', event: '[provision/video] failed' },
+      '[provision/video] provision failed; image session continues image-only',
     );
-    terminatePod(podId).catch((e) =>
-      log.warn({ podId, err: (e as Error).message }, '[provision/video] terminate-after-fail failed'),
-    );
-    // Clear the row stamp we wrote above so the next reconnect does a
-    // fresh provision instead of probing this dead pod.
-    await clearVideoPod(sessionId).catch(() => {});
     return null;
   }
 }
 
-/** Terminate a video pod by ID. Never throws. */
+/**
+ * Replace a session's video pod after it dies mid-session. Mirror of
+ * `replaceSession` for the video kind: terminate the old video pod,
+ * reprovision via the shared loop, return the new pod info or null on
+ * failure. Called by stream.ts's `handleVideoUpstreamClose` after a
+ * same-pod reconnect attempt fails (i.e., the pod is truly gone, not
+ * just a transient WS drop).
+ *
+ * Best-effort contract: returns null on any failure. Caller falls back
+ * to image-only.
+ */
+export async function replaceVideoSession(
+  sessionId: string,
+): Promise<{ podId: string; podUrl: string } | null> {
+  const session = await readSession(sessionId);
+  if (!session) {
+    log.warn({ sessionId }, 'replaceVideoSession: no session to replace');
+    return null;
+  }
+  const oldPodId = session.videoPodId;
+  log.info({ sessionId, oldPodId, pod_kind: 'video' }, 'Starting video session replacement');
+
+  // Clear old pod ref + terminate (fire-and-forget). No replacement-count
+  // bump — we share session.replacementCount with image, and video failures
+  // are recoverable enough that we don't want to consume the budget.
+  await clearVideoPod(sessionId).catch(() => {});
+  if (oldPodId) {
+    terminatePod(oldPodId).catch((e) =>
+      log.warn(
+        { sessionId, oldPodId, err: (e as Error).message },
+        'replaceVideoSession: terminate old pod failed (reaper will clean)',
+      ),
+    );
+  }
+
+  // Co-locate the replacement with image pod's current DC.
+  let preferredDc: string | undefined;
+  if (session.podId) {
+    const imagePod = await getPod(session.podId).catch(() => null);
+    if (imagePod?.machine?.dataCenterId) {
+      preferredDc = imagePod.machine.dataCenterId;
+    }
+  }
+
+  const key = `video:${sessionId}`;
+  const promise = (async () => {
+    try {
+      return await _runProvisionLoop('video', sessionId, { preferredDc });
+    } finally {
+      inFlightProvisions.delete(key);
+    }
+  })();
+  inFlightProvisions.set(key, promise);
+  try {
+    const r = await promise;
+    return { podId: r.podId, podUrl: r.podUrl };
+  } catch (err) {
+    log.warn(
+      { sessionId, err: (err as Error).message, pod_kind: 'video' },
+      'replaceVideoSession failed; session is image-only',
+    );
+    return null;
+  }
+}
+
+/** Terminate a video pod by ID. Never throws. Used by stream.ts on relay
+ *  wire failure. */
 export async function terminateVideoPod(podId: string): Promise<void> {
   try {
     await terminatePod(podId);
@@ -1272,22 +1339,8 @@ export async function terminateVideoPod(podId: string): Promise<void> {
   }
 }
 
-/** Stash the just-provisioned video pod ID on the session row so reaper +
- *  reconcile can find it. Best-effort: if the session row doesn't exist
- *  (somehow already cleaned up), silently skip — the reconciler will
- *  terminate this pod as an orphan within a minute. */
-export async function setVideoPod(sessionId: string, videoPodId: string): Promise<void> {
-  try {
-    await patchSession(sessionId, { videoPodId });
-  } catch (err) {
-    log.warn(
-      { sessionId, videoPodId, err: (err as Error).message },
-      'setVideoPod patchSession failed (orphan will be reconciled)',
-    );
-  }
-}
-
-/** Clear videoPodId on session row (e.g. after stream close). Never throws. */
+/** Clear videoPodId on session row. Never throws. Used by stream.ts on
+ *  relay wire failure to ensure the next reconnect provisions fresh. */
 export async function clearVideoPod(sessionId: string): Promise<void> {
   try {
     await patchSession(sessionId, { videoPodId: null });
@@ -1297,98 +1350,6 @@ export async function clearVideoPod(sessionId: string): Promise<void> {
       'clearVideoPod patchSession failed',
     );
   }
-}
-
-/**
- * Get-or-provision the video pod for a session. Mirrors getOrProvisionPod
- * for image pods: on iPad WS reconnect, the video pod outlives the WS and
- * is reused, avoiding the ~3-min LTXV cold start on every drawing change.
- *
- * Returns null on any provision failure (best-effort, same contract as
- * provisionVideoPod).
- *
- * Stale-id handling: if the session row references a videoPodId that's
- * gone from RunPod (terminated externally, reconciled, etc.), we clear
- * the stale id and provision fresh.
- */
-export async function getOrProvisionVideoPod(
-  sessionId: string,
-): Promise<{ podId: string; podUrl: string } | null> {
-  const existing = await readSession(sessionId);
-  if (existing?.videoPodId) {
-    const pod = await getPod(existing.videoPodId).catch(() => null);
-    const ready = pod && pod.desiredStatus === 'RUNNING' && pod.runtime !== null;
-    if (ready) {
-      const podUrl = `wss://${existing.videoPodId}-8766.proxy.runpod.net/ws`;
-      log.info(
-        { sessionId, videoPodId: existing.videoPodId, pod_kind: 'video', event: '[provision/video] reused' },
-        '[provision/video] reusing existing pod (no cold start)',
-      );
-      return { podId: existing.videoPodId, podUrl };
-    }
-    if (pod && pod.desiredStatus === 'RUNNING' && pod.runtime === null) {
-      // Pod exists and is desired-running, but runtime hasn't appeared
-      // yet — it's mid-boot, likely from a concurrent in-flight provision
-      // on this same backend instance. Joining the in-flight promise (if
-      // present) gets us the correct result without starting a duplicate.
-      const inFlight = inFlightVideoProvisions.get(sessionId);
-      if (inFlight) {
-        log.info(
-          { sessionId, videoPodId: existing.videoPodId, pod_kind: 'video', event: '[provision/video] joined in-flight' },
-          '[provision/video] pod still booting; joining in-flight provision',
-        );
-        return inFlight;
-      }
-      // Booting but not in-flight on this instance — likely a different
-      // backend replica owns it, or the original promise lost track on
-      // restart. Fall through to fresh provision; the orphan will be
-      // cleaned up by reconcile.
-      log.warn(
-        { sessionId, videoPodId: existing.videoPodId, pod_kind: 'video' },
-        '[provision/video] pod booting but no in-flight promise here; reprovisioning',
-      );
-    } else {
-      log.info(
-        { sessionId, videoPodId: existing.videoPodId, status: pod?.desiredStatus ?? 'gone', pod_kind: 'video', event: '[provision/video] stale id' },
-        '[provision/video] stashed videoPodId is stale; reprovisioning',
-      );
-    }
-    await clearVideoPod(sessionId).catch(() => {});
-  }
-
-  const inFlight = inFlightVideoProvisions.get(sessionId);
-  if (inFlight) {
-    log.info(
-      { sessionId, pod_kind: 'video', event: '[provision/video] joined in-flight' },
-      '[provision/video] joining in-flight provision (no row stamp yet)',
-    );
-    return inFlight;
-  }
-
-  // Co-locate with the image pod's DC if we know it. The image pod may
-  // already be in a working DC (possibly via reroll) — sticking the video
-  // pod there avoids cross-DC trigger latency AND avoids landing the
-  // video pod in a DC that's currently broken (e.g. US-NC-1 host issues
-  // we've seen). If the image pod hasn't been placed yet (parallel
-  // provision starting up), we have no preference and fall back to
-  // selectPlacement's default ranking.
-  let preferredDc: string | undefined;
-  if (existing?.podId) {
-    const imagePod = await getPod(existing.podId).catch(() => null);
-    if (imagePod?.machine?.dataCenterId) {
-      preferredDc = imagePod.machine.dataCenterId;
-    }
-  }
-
-  const promise = (async () => {
-    try {
-      return await provisionVideoPod(sessionId, preferredDc);
-    } finally {
-      inFlightVideoProvisions.delete(sessionId);
-    }
-  })();
-  inFlightVideoProvisions.set(sessionId, promise);
-  return promise;
 }
 
 /**

--- a/backend/src/routes/stream.ts
+++ b/backend/src/routes/stream.ts
@@ -12,6 +12,10 @@ import {
   sessionClosed,
   subscribe,
   emitState,
+  provisionVideoPod,
+  terminateVideoPod,
+  setVideoPod,
+  clearVideoPod,
 } from '../modules/orchestrator/orchestrator.js';
 import { StreamRelay } from '../modules/relay/streamRelay.js';
 import {
@@ -138,6 +142,29 @@ export const streamRoute: FastifyPluginAsync = async (fastify) => {
       let clientDisconnected = false;
       const sessionStartMs = Date.now();
 
+      // ─── Video pod state (best-effort, see provisionVideoPod) ─────────
+      let videoRelay: StreamRelay | null = null;
+      let videoPodId: string | null = null;
+      // Once the upstream video relay closes uninitiated we don't try
+      // again for this session — image gen continues normally.
+      let videoSessionEnabled = true;
+      // Captured from the last frame_meta JSON; consumed when the
+      // following binary lands. The pair tells us "this image is video-
+      // eligible" — pod-side authoritative, more robust than a backend
+      // counter.
+      let nextImageBinaryQueueEmpty = false;
+      let nextImageBinaryRequestId: string | null = null;
+      // Set when we forward a binary from the video pod. The next text
+      // preamble gets matched with the binary that immediately follows.
+      let pendingVideoBinaryWrapper: { type: string; meta: Record<string, unknown> } | null = null;
+      let inFlightVideoRequestId: string | null = null;
+      // Counters reported in the session_close summary (paste-friendly
+      // for the triage cookbook in documents/plans/drawing-animation.md).
+      let videoTriggered = 0;
+      let videoCompleted = 0;
+      let videoCancelled = 0;
+      let videoFailed = 0;
+
       // Subscribe to provision state events so the iOS client sees every
       // transition — fresh caller AND joiner both go through this single path.
       // The broker seeds the handler with the current Redis state (if any),
@@ -170,10 +197,71 @@ export const streamRoute: FastifyPluginAsync = async (fastify) => {
           if (socket.readyState !== socket.OPEN) return;
           touch(userId);
           if (isBinary) {
-            const base64 = (data as Buffer).toString('base64');
+            const buf = data as Buffer;
+            const base64 = buf.toString('base64');
             socket.send(JSON.stringify({ type: 'frame', data: base64 }));
+
+            // Video trigger: the immediately preceding frame_meta said
+            // queueEmpty:true, so this JPEG is the just-completed
+            // generation that the user is now idle on. Forward it to
+            // the video pod for animation. Pod-side queueEmpty is the
+            // authoritative idle signal — see flux-klein-server/server.py.
+            if (nextImageBinaryQueueEmpty) {
+              if (!videoSessionEnabled) {
+                request.log.info(
+                  { userId, reason: 'session_disabled', event: 'video_skipped' },
+                  'video_skipped',
+                );
+              } else if (!videoRelay) {
+                request.log.info(
+                  { userId, reason: 'relay_disconnected', event: 'video_skipped' },
+                  'video_skipped',
+                );
+              } else if (!lastConfig || typeof lastConfig['prompt'] !== 'string') {
+                request.log.warn(
+                  { userId, reason: 'prompt_not_cached', event: 'video_skipped' },
+                  'video_skipped',
+                );
+              } else {
+                const reqId = nextImageBinaryRequestId ?? `vid-${Date.now()}`;
+                videoRelay.sendConfig({
+                  type: 'video_request',
+                  requestId: reqId,
+                  image_b64: base64,
+                  prompt: lastConfig['prompt'],
+                });
+                inFlightVideoRequestId = reqId;
+                videoTriggered++;
+                request.log.info(
+                  {
+                    userId,
+                    req: reqId,
+                    promptCached: true,
+                    videoRelayConnected: true,
+                    event: 'video_trigger',
+                  },
+                  'video_trigger',
+                );
+              }
+            }
+            nextImageBinaryQueueEmpty = false;
+            nextImageBinaryRequestId = null;
           } else {
+            // Forward text frames (frame_meta, status, error) to the iPad
+            // unchanged. Sniff frame_meta to capture queueEmpty for the
+            // following binary.
             socket.send(data);
+            if (typeof data === 'string') {
+              try {
+                const parsed = JSON.parse(data) as Record<string, unknown>;
+                if (parsed['type'] === 'frame_meta') {
+                  nextImageBinaryQueueEmpty = parsed['queueEmpty'] === true;
+                  nextImageBinaryRequestId = (parsed['requestId'] as string | null) ?? null;
+                }
+              } catch {
+                // Not JSON; ignore — relay forwards opaquely.
+              }
+            }
           }
         });
         newRelay.onClose(handleUpstreamClose);
@@ -184,6 +272,67 @@ export const streamRoute: FastifyPluginAsync = async (fastify) => {
         relay = newRelay;
         currentPodUrl = podUrl;
         if (lastConfig) newRelay.sendConfig(lastConfig);
+      };
+
+      // ─── Video relay wiring ────────────────────────────────────────────
+      // Best-effort: provisionVideoPod returns null on any failure, in which
+      // case videoRelay stays null and queueEmpty triggers log a single
+      // 'video_skipped: relay_disconnected' line. No iPad-visible error.
+      const wireVideoRelay = async (podUrl: string): Promise<void> => {
+        const newRelay = new StreamRelay(podUrl);
+        newRelay.onMessage((data, isBinary) => {
+          if (socket.readyState !== socket.OPEN) return;
+          touch(userId);
+          if (isBinary) {
+            const buf = data as Buffer;
+            const base64 = buf.toString('base64');
+            // The text preamble that arrived just before this binary tells
+            // us how to wrap it for the iPad. Falls back to a generic
+            // wrapper if (somehow) no preamble was seen — iPad will log
+            // and drop the frame.
+            const wrap = pendingVideoBinaryWrapper;
+            pendingVideoBinaryWrapper = null;
+            const wrapperType = wrap?.type === 'video_complete' ? 'video_complete_data'
+              : wrap?.type === 'video_frame' ? 'video_frame_data'
+              : 'video_unknown_data';
+            socket.send(JSON.stringify({ type: wrapperType, data: base64, meta: wrap?.meta ?? {} }));
+          } else if (typeof data === 'string') {
+            // Forward text frames and update counters. The pod sends the
+            // type before the binary, so we cache the type for the
+            // upcoming binary to consume.
+            try {
+              const parsed = JSON.parse(data) as Record<string, unknown>;
+              const t = parsed['type'];
+              if (t === 'video_frame' || t === 'video_complete') {
+                pendingVideoBinaryWrapper = { type: t as string, meta: parsed };
+              } else if (t === 'video_cancelled') {
+                videoCancelled++;
+                inFlightVideoRequestId = null;
+                pendingVideoBinaryWrapper = null;
+              }
+              if (t === 'video_complete') {
+                videoCompleted++;
+                inFlightVideoRequestId = null;
+              }
+            } catch {
+              // Not JSON; ignore.
+            }
+            socket.send(data);
+          }
+        });
+        newRelay.onClose((code, reason) => {
+          request.log.warn(
+            { userId, code, reason, event: 'video_relay_closed', sessionDisabled: true },
+            'video_relay_closed',
+          );
+          videoSessionEnabled = false;
+          videoRelay = null;
+        });
+        newRelay.onError((err) => {
+          request.log.warn({ userId, err: err.message }, 'video relay error');
+        });
+        await newRelay.connect();
+        videoRelay = newRelay;
       };
 
       // Recover from an upstream close. If the iPad WS is still open, always
@@ -300,12 +449,76 @@ export const streamRoute: FastifyPluginAsync = async (fastify) => {
         }
         request.log.info({ userId }, 'Upstream connected, relaying');
 
+        // Kick off video pod provisioning in the background. We don't await
+        // — the user's image flow is unblocked the moment the image relay
+        // is up. When the video pod resolves, we wire it; if it fails or
+        // takes too long, queueEmpty triggers log 'video_skipped' and the
+        // session continues image-only. See provisionVideoPod for the
+        // best-effort semantics.
+        void (async () => {
+          try {
+            const result = await provisionVideoPod(userId);
+            if (!result || clientDisconnected || socket.readyState !== socket.OPEN) {
+              if (result) {
+                // Client left during provision — clean up immediately.
+                terminateVideoPod(result.podId).catch(() => {});
+              }
+              return;
+            }
+            videoPodId = result.podId;
+            await setVideoPod(userId, result.podId);
+            try {
+              await wireVideoRelay(result.podUrl);
+              request.log.info(
+                { userId, videoPodId, event: '[provision/video] relay wired' },
+                'video relay wired',
+              );
+            } catch (err) {
+              request.log.warn(
+                { userId, videoPodId, err: (err as Error).message, event: '[provision/video] relay connect failed' },
+                'video relay connect failed; terminating pod',
+              );
+              terminateVideoPod(result.podId).catch(() => {});
+              videoPodId = null;
+              await clearVideoPod(userId);
+              videoSessionEnabled = false;
+            }
+          } catch (err) {
+            request.log.warn(
+              { userId, err: (err as Error).message, event: '[provision/video] unexpected throw' },
+              'provisionVideoPod unexpectedly threw (returns null on failure normally)',
+            );
+            videoSessionEnabled = false;
+          }
+        })();
+
         socket.on('message', (data: Buffer | ArrayBuffer | Buffer[], isBinary: boolean) => {
           if (!relay) return;
           const buf = Array.isArray(data) ? Buffer.concat(data) : Buffer.from(data as ArrayBuffer);
           touch(userId);
           if (isBinary) {
             relay.sendFrame(buf);
+            // A new sketch from the iPad supersedes any in-flight video.
+            // Send video_cancel on EVERY iPad frame while a video request
+            // is in flight; the pod treats it idempotently. Once the
+            // video pod responds with video_cancelled, we clear the id.
+            if (inFlightVideoRequestId && videoRelay) {
+              const t0 = Date.now();
+              videoRelay.sendConfig({
+                type: 'video_cancel',
+                requestId: inFlightVideoRequestId,
+              });
+              request.log.info(
+                {
+                  userId,
+                  req: inFlightVideoRequestId,
+                  elapsedSinceRequestMs: t0 - sessionStartMs,
+                  event: 'video_cancel_sent',
+                },
+                'video_cancel_sent',
+              );
+              inFlightVideoRequestId = null;
+            }
           } else {
             const text = buf.toString('utf-8');
             try {
@@ -358,17 +571,46 @@ export const streamRoute: FastifyPluginAsync = async (fastify) => {
 
       socket.on('close', () => {
         clientDisconnected = true;
-        request.log.info({ userId }, 'Stream client disconnected');
-        trackSessionClosed({ userId, durationMs: Date.now() - sessionStartMs });
+        const durationMs = Date.now() - sessionStartMs;
+        request.log.info(
+          {
+            userId,
+            durationMs,
+            videoTriggered,
+            videoCompleted,
+            videoCancelled,
+            videoFailed,
+            event: 'session_close',
+          },
+          'session_close',
+        );
+        trackSessionClosed({ userId, durationMs });
         sessionClosed(userId);
         unsubscribeState();
         relay?.close();
+        videoRelay?.close();
+        // Terminate the video pod immediately on stream close — it has no
+        // useful work to do once the iPad is gone, and the reaper would
+        // only catch it on the next minute boundary.
+        if (videoPodId) {
+          const podIdAtClose = videoPodId;
+          videoPodId = null;
+          terminateVideoPod(podIdAtClose).catch(() => {});
+          clearVideoPod(userId).catch(() => {});
+        }
       });
 
       socket.on('error', (err: Error) => {
         request.log.error({ userId, err }, 'Client socket error');
         unsubscribeState();
         relay?.close();
+        videoRelay?.close();
+        if (videoPodId) {
+          const podIdAtClose = videoPodId;
+          videoPodId = null;
+          terminateVideoPod(podIdAtClose).catch(() => {});
+          clearVideoPod(userId).catch(() => {});
+        }
       });
     })();
   });

--- a/backend/src/routes/stream.ts
+++ b/backend/src/routes/stream.ts
@@ -297,29 +297,38 @@ export const streamRoute: FastifyPluginAsync = async (fastify) => {
               : 'video_unknown_data';
             socket.send(JSON.stringify({ type: wrapperType, data: base64, meta: wrap?.meta ?? {} }));
           } else if (typeof data === 'string') {
-            // Forward text frames and update counters. The pod sends the
-            // type before the binary, so we cache the type for the
-            // upcoming binary to consume.
+            // The pod sends the preamble type before the binary, so we cache
+            // the type and forward the *_data wrapped binary on arrival.
+            // Bare preambles (video_frame, video_complete) are NOT forwarded
+            // — the iPad has no handler for them, so forwarding is wasted
+            // bandwidth (~one extra WS message per decoded frame).
+            let parsed: Record<string, unknown> | null = null;
             try {
-              const parsed = JSON.parse(data) as Record<string, unknown>;
-              const t = parsed['type'];
-              if (t === 'video_frame' || t === 'video_complete') {
-                pendingVideoBinaryWrapper = { type: t as string, meta: parsed };
-              } else if (t === 'video_cancelled') {
-                if (parsed['error']) {
-                  videoFailed++;
-                } else {
-                  videoCancelled++;
-                }
-                inFlightVideoRequestId = null;
-                pendingVideoBinaryWrapper = null;
-              }
+              parsed = JSON.parse(data) as Record<string, unknown>;
+            } catch {
+              // Not JSON — pass through opaquely below.
+            }
+            if (parsed === null) {
+              socket.send(data);
+              return;
+            }
+            const t = parsed['type'];
+            if (t === 'video_frame' || t === 'video_complete') {
+              pendingVideoBinaryWrapper = { type: t as string, meta: parsed };
               if (t === 'video_complete') {
                 videoCompleted++;
                 inFlightVideoRequestId = null;
               }
-            } catch {
-              // Not JSON; ignore.
+              return; // bare preamble — wrapped *_data goes out on the binary path
+            }
+            if (t === 'video_cancelled') {
+              if (parsed['error']) {
+                videoFailed++;
+              } else {
+                videoCancelled++;
+              }
+              inFlightVideoRequestId = null;
+              pendingVideoBinaryWrapper = null;
             }
             socket.send(data);
           }

--- a/backend/src/routes/stream.ts
+++ b/backend/src/routes/stream.ts
@@ -13,8 +13,8 @@ import {
   subscribe,
   emitState,
   getOrProvisionVideoPod,
+  replaceVideoSession,
   terminateVideoPod,
-  setVideoPod,
   clearVideoPod,
 } from '../modules/orchestrator/orchestrator.js';
 import { StreamRelay } from '../modules/relay/streamRelay.js';
@@ -343,20 +343,81 @@ export const streamRoute: FastifyPluginAsync = async (fastify) => {
             socket.send(data);
           }
         });
-        newRelay.onClose((code, reason) => {
-          request.log.warn(
-            { userId, code, reason, event: 'video_relay_closed', sessionDisabled: true },
-            'video_relay_closed',
-          );
-          videoSessionEnabled = false;
-          videoRelay = null;
-        });
+        newRelay.onClose((code, reason) => handleVideoUpstreamClose(code, reason));
         newRelay.onError((err) => {
           request.log.warn({ userId, err: err.message }, 'video relay error');
         });
         await newRelay.connect();
         videoRelay = newRelay;
       };
+
+      // Mirror of handleUpstreamClose for the video pod's relay. Same
+      // policy: same-pod reconnect first (transient transport drop), then
+      // replaceVideoSession if that fails (pod truly gone). On final
+      // failure, drop to image-only — video is best-effort, no iPad-visible
+      // error.
+      function handleVideoUpstreamClose(code: number, reason: string): void {
+        request.log.warn(
+          { userId, code, reason, event: 'video_relay_closed' },
+          'video_relay_closed',
+        );
+
+        if (clientDisconnected || socket.readyState !== socket.OPEN) {
+          // Client already left; don't try to recover.
+          videoSessionEnabled = false;
+          videoRelay = null;
+          return;
+        }
+
+        // Stop any residual events from the dead relay.
+        videoRelay?.close();
+        videoRelay = null;
+
+        void (async () => {
+          // Fast path: same-pod reconnect. RunPod proxy idle timeout or
+          // network blip; pod is still serving — succeeds in ~1–2 s.
+          if (videoPodId) {
+            const samePodUrl = `wss://${videoPodId}-8766.proxy.runpod.net/ws`;
+            try {
+              await wireVideoRelay(samePodUrl);
+              request.log.info(
+                { userId, videoPodId, event: 'video_relay_reconnected' },
+                'video same-pod reconnect succeeded',
+              );
+              return;
+            } catch (reconnectErr) {
+              request.log.info(
+                { userId, videoPodId, err: (reconnectErr as Error).message },
+                'video same-pod reconnect failed; trying replaceVideoSession',
+              );
+            }
+          }
+
+          // Slow path: replace the pod. Best-effort; null on failure.
+          if (clientDisconnected || socket.readyState !== socket.OPEN) return;
+          const result = await replaceVideoSession(userId);
+          if (!result || clientDisconnected || socket.readyState !== socket.OPEN) {
+            videoSessionEnabled = false;
+            videoPodId = null;
+            return;
+          }
+          videoPodId = result.podId;
+          try {
+            await wireVideoRelay(result.podUrl);
+            request.log.info(
+              { userId, videoPodId, event: 'video_relay_replaced' },
+              'video pod replaced; relay re-wired',
+            );
+          } catch (err) {
+            request.log.warn(
+              { userId, videoPodId, err: (err as Error).message },
+              'video replacement relay-wire failed; image-only',
+            );
+            videoSessionEnabled = false;
+            videoPodId = null;
+          }
+        })();
+      }
 
       // Recover from an upstream close. If the iPad WS is still open, always
       // attempt recovery: first a same-pod reconnect (transient transport
@@ -464,7 +525,8 @@ export const streamRoute: FastifyPluginAsync = async (fastify) => {
               return;
             }
             videoPodId = result.podId;
-            await setVideoPod(userId, result.podId);
+            // Helper stamps the row's videoPodId field internally during
+            // provision; no need to do it again here.
             try {
               await wireVideoRelay(result.podUrl);
               request.log.info(

--- a/backend/src/routes/stream.ts
+++ b/backend/src/routes/stream.ts
@@ -442,53 +442,25 @@ export const streamRoute: FastifyPluginAsync = async (fastify) => {
           await recordProvision(userId);
         }
 
-        const getOrProvisionStart = Date.now();
-        const { podUrl } = await getOrProvisionPod(userId);
-        getOrProvisionMs = Date.now() - getOrProvisionStart;
-
-        if (socket.readyState !== socket.OPEN) {
-          request.log.info({ userId }, 'Client disconnected during provisioning');
-          return;
-        }
-
-        // Pod is serving; transition to 'connecting' while we wire up the relay.
-        await emitState(userId, 'connecting');
-        // Retry initial relay connect once. Occasionally RunPod's proxy
-        // fails to upgrade the first WS to a freshly-ready pod: /health
-        // returns ok but the /ws upgrade on the same pod 10 s later hangs
-        // (observed 2026-04-25 02:30 UTC — pod was healthy, connect
-        // timed out). A brief second attempt usually succeeds; if it
-        // doesn't, the outer catch aborts the session cleanly.
-        try {
-          await wireRelay(podUrl);
-        } catch (firstErr) {
-          if (clientDisconnected || socket.readyState !== socket.OPEN) throw firstErr;
-          request.log.warn(
-            { userId, podUrl, err: (firstErr as Error).message },
-            'Initial relay connect failed, retrying in 2s',
-          );
-          await new Promise((r) => setTimeout(r, 2000));
-          await wireRelay(podUrl);
-        }
-        request.log.info({ userId }, 'Upstream connected, relaying');
-
-        // Kick off video pod provisioning in the background, gated by
-        // VIDEO_POD_ENABLED so we can deploy backend-side changes ahead
-        // of the pod-side code reaching the network volume. When disabled,
-        // queueEmpty triggers log 'video_skipped: relay_disconnected' and
-        // the session continues image-only — same code path as a runtime
-        // video provision failure.
+        // Kick off video pod provisioning IN PARALLEL with image. The image
+        // pod gating user input takes ~96s cold; running video alongside
+        // (~157s LTXV warmup) saves ~96s of time-to-first-video vs starting
+        // it after image is wired. Video is best-effort: any failure here
+        // logs and falls back to image-only without affecting the image
+        // path. Race note: getOrProvisionVideoPod reads the session row
+        // for an existing videoPodId; for fresh sessions the row gets
+        // written by getOrProvisionPod kicked off below, but for new
+        // sessions there's no prior pod to reuse anyway, so the race is
+        // benign.
         if (config.VIDEO_POD_ENABLED) {
           void (async () => {
           try {
             const result = await getOrProvisionVideoPod(userId);
             if (!result || clientDisconnected || socket.readyState !== socket.OPEN) {
-              if (result) {
-                // Client left during provision/reuse. We don't terminate
-                // here — the pod (whether fresh or reused) is on the
-                // session row and will be picked up by the next reconnect
-                // or terminated by the reaper alongside the image pod.
-              }
+              // Client left during provision/reuse. We don't terminate
+              // here — the pod (whether fresh or reused) is on the
+              // session row and will be picked up by the next reconnect
+              // or terminated by the reaper alongside the image pod.
               return;
             }
             videoPodId = result.podId;
@@ -529,6 +501,36 @@ export const streamRoute: FastifyPluginAsync = async (fastify) => {
           );
           videoSessionEnabled = false;
         }
+
+        const getOrProvisionStart = Date.now();
+        const { podUrl } = await getOrProvisionPod(userId);
+        getOrProvisionMs = Date.now() - getOrProvisionStart;
+
+        if (socket.readyState !== socket.OPEN) {
+          request.log.info({ userId }, 'Client disconnected during provisioning');
+          return;
+        }
+
+        // Pod is serving; transition to 'connecting' while we wire up the relay.
+        await emitState(userId, 'connecting');
+        // Retry initial relay connect once. Occasionally RunPod's proxy
+        // fails to upgrade the first WS to a freshly-ready pod: /health
+        // returns ok but the /ws upgrade on the same pod 10 s later hangs
+        // (observed 2026-04-25 02:30 UTC — pod was healthy, connect
+        // timed out). A brief second attempt usually succeeds; if it
+        // doesn't, the outer catch aborts the session cleanly.
+        try {
+          await wireRelay(podUrl);
+        } catch (firstErr) {
+          if (clientDisconnected || socket.readyState !== socket.OPEN) throw firstErr;
+          request.log.warn(
+            { userId, podUrl, err: (firstErr as Error).message },
+            'Initial relay connect failed, retrying in 2s',
+          );
+          await new Promise((r) => setTimeout(r, 2000));
+          await wireRelay(podUrl);
+        }
+        request.log.info({ userId }, 'Upstream connected, relaying');
 
         socket.on('message', (data: Buffer | ArrayBuffer | Buffer[], isBinary: boolean) => {
           if (!relay) return;

--- a/backend/src/routes/stream.ts
+++ b/backend/src/routes/stream.ts
@@ -453,13 +453,14 @@ export const streamRoute: FastifyPluginAsync = async (fastify) => {
         }
         request.log.info({ userId }, 'Upstream connected, relaying');
 
-        // Kick off video pod provisioning in the background. We don't await
-        // — the user's image flow is unblocked the moment the image relay
-        // is up. When the video pod resolves, we wire it; if it fails or
-        // takes too long, queueEmpty triggers log 'video_skipped' and the
-        // session continues image-only. See provisionVideoPod for the
-        // best-effort semantics.
-        void (async () => {
+        // Kick off video pod provisioning in the background, gated by
+        // VIDEO_POD_ENABLED so we can deploy backend-side changes ahead
+        // of the pod-side code reaching the network volume. When disabled,
+        // queueEmpty triggers log 'video_skipped: relay_disconnected' and
+        // the session continues image-only — same code path as a runtime
+        // video provision failure.
+        if (config.VIDEO_POD_ENABLED) {
+          void (async () => {
           try {
             const result = await provisionVideoPod(userId);
             if (!result || clientDisconnected || socket.readyState !== socket.OPEN) {
@@ -494,7 +495,14 @@ export const streamRoute: FastifyPluginAsync = async (fastify) => {
             );
             videoSessionEnabled = false;
           }
-        })();
+          })();
+        } else {
+          request.log.info(
+            { userId, event: '[provision/video] disabled by config' },
+            'video pod disabled (VIDEO_POD_ENABLED=false); session is image-only',
+          );
+          videoSessionEnabled = false;
+        }
 
         socket.on('message', (data: Buffer | ArrayBuffer | Buffer[], isBinary: boolean) => {
           if (!relay) return;

--- a/backend/src/routes/stream.ts
+++ b/backend/src/routes/stream.ts
@@ -413,8 +413,13 @@ export const streamRoute: FastifyPluginAsync = async (fastify) => {
               { userId, videoPodId, err: (err as Error).message },
               'video replacement relay-wire failed; image-only',
             );
-            videoSessionEnabled = false;
+            // The replacement pod is alive but unreachable. Eagerly clean
+            // up so it doesn't sit idle until reconcile. Mirrors the
+            // initial-provision wire-failure handling above.
+            terminateVideoPod(result.podId).catch(() => {});
+            await clearVideoPod(userId).catch(() => {});
             videoPodId = null;
+            videoSessionEnabled = false;
           }
         })();
       }

--- a/backend/src/routes/stream.ts
+++ b/backend/src/routes/stream.ts
@@ -12,7 +12,7 @@ import {
   sessionClosed,
   subscribe,
   emitState,
-  provisionVideoPod,
+  getOrProvisionVideoPod,
   terminateVideoPod,
   setVideoPod,
   clearVideoPod,
@@ -142,7 +142,7 @@ export const streamRoute: FastifyPluginAsync = async (fastify) => {
       let clientDisconnected = false;
       const sessionStartMs = Date.now();
 
-      // ─── Video pod state (best-effort, see provisionVideoPod) ─────────
+      // ─── Video pod state (best-effort, see getOrProvisionVideoPod) ────
       let videoRelay: StreamRelay | null = null;
       let videoPodId: string | null = null;
       // Once the upstream video relay closes uninitiated we don't try
@@ -222,6 +222,16 @@ export const streamRoute: FastifyPluginAsync = async (fastify) => {
                   { userId, reason: 'prompt_not_cached', event: 'video_skipped' },
                   'video_skipped',
                 );
+              } else if (inFlightVideoRequestId) {
+                // A video is mid-generation. Don't fire another trigger —
+                // the pod would cancel the in-flight one to start a new
+                // request, starving us of any completion. Wait for the
+                // current video to finish (or be cancelled by the user
+                // resuming drawing) before triggering again.
+                request.log.info(
+                  { userId, reason: 'already_in_flight', inFlightReq: inFlightVideoRequestId, event: 'video_skipped' },
+                  'video_skipped',
+                );
               } else {
                 const reqId = nextImageBinaryRequestId ?? `vid-${Date.now()}`;
                 videoRelay.sendConfig({
@@ -275,7 +285,7 @@ export const streamRoute: FastifyPluginAsync = async (fastify) => {
       };
 
       // ─── Video relay wiring ────────────────────────────────────────────
-      // Best-effort: provisionVideoPod returns null on any failure, in which
+      // Best-effort: getOrProvisionVideoPod returns null on any failure, in which
       // case videoRelay stays null and queueEmpty triggers log a single
       // 'video_skipped: relay_disconnected' line. No iPad-visible error.
       const wireVideoRelay = async (podUrl: string): Promise<void> => {
@@ -471,11 +481,13 @@ export const streamRoute: FastifyPluginAsync = async (fastify) => {
         if (config.VIDEO_POD_ENABLED) {
           void (async () => {
           try {
-            const result = await provisionVideoPod(userId);
+            const result = await getOrProvisionVideoPod(userId);
             if (!result || clientDisconnected || socket.readyState !== socket.OPEN) {
               if (result) {
-                // Client left during provision — clean up immediately.
-                terminateVideoPod(result.podId).catch(() => {});
+                // Client left during provision/reuse. We don't terminate
+                // here — the pod (whether fresh or reused) is on the
+                // session row and will be picked up by the next reconnect
+                // or terminated by the reaper alongside the image pod.
               }
               return;
             }
@@ -488,6 +500,11 @@ export const streamRoute: FastifyPluginAsync = async (fastify) => {
                 'video relay wired',
               );
             } catch (err) {
+              // Relay connect failed for an otherwise-live pod. Terminate
+              // + clear so the next reconnect provisions fresh (avoids
+              // looping on a broken pod). The reaper would catch this
+              // anyway, but eagerly clearing keeps the next session
+              // healthy without a 30-min wait.
               request.log.warn(
                 { userId, videoPodId, err: (err as Error).message, event: '[provision/video] relay connect failed' },
                 'video relay connect failed; terminating pod',
@@ -500,7 +517,7 @@ export const streamRoute: FastifyPluginAsync = async (fastify) => {
           } catch (err) {
             request.log.warn(
               { userId, err: (err as Error).message, event: '[provision/video] unexpected throw' },
-              'provisionVideoPod unexpectedly threw (returns null on failure normally)',
+              'getOrProvisionVideoPod unexpectedly threw (returns null on failure normally)',
             );
             videoSessionEnabled = false;
           }
@@ -609,16 +626,13 @@ export const streamRoute: FastifyPluginAsync = async (fastify) => {
         sessionClosed(userId);
         unsubscribeState();
         relay?.close();
+        // Close the video relay WS so the pod sees the disconnect and stops
+        // any in-flight generation, but DO NOT terminate the pod itself.
+        // The pod is Redis-tracked on the session row; the next iPad
+        // reconnect will reuse it via getOrProvisionVideoPod (no 3-min
+        // cold start). The reaper terminates the pod when the image
+        // session itself is reaped (orchestrator.ts: runReaper).
         videoRelay?.close();
-        // Terminate the video pod immediately on stream close — it has no
-        // useful work to do once the iPad is gone, and the reaper would
-        // only catch it on the next minute boundary.
-        if (videoPodId) {
-          const podIdAtClose = videoPodId;
-          videoPodId = null;
-          terminateVideoPod(podIdAtClose).catch(() => {});
-          clearVideoPod(userId).catch(() => {});
-        }
       });
 
       socket.on('error', (err: Error) => {
@@ -626,12 +640,6 @@ export const streamRoute: FastifyPluginAsync = async (fastify) => {
         unsubscribeState();
         relay?.close();
         videoRelay?.close();
-        if (videoPodId) {
-          const podIdAtClose = videoPodId;
-          videoPodId = null;
-          terminateVideoPod(podIdAtClose).catch(() => {});
-          clearVideoPod(userId).catch(() => {});
-        }
       });
     })();
   });

--- a/backend/src/routes/stream.ts
+++ b/backend/src/routes/stream.ts
@@ -306,7 +306,11 @@ export const streamRoute: FastifyPluginAsync = async (fastify) => {
               if (t === 'video_frame' || t === 'video_complete') {
                 pendingVideoBinaryWrapper = { type: t as string, meta: parsed };
               } else if (t === 'video_cancelled') {
-                videoCancelled++;
+                if (parsed['error']) {
+                  videoFailed++;
+                } else {
+                  videoCancelled++;
+                }
                 inFlightVideoRequestId = null;
                 pendingVideoBinaryWrapper = null;
               }

--- a/documents/plans/drawing-animation.md
+++ b/documents/plans/drawing-animation.md
@@ -223,6 +223,107 @@ Trigger flow:
    `swift test --package-path ios/Packages/CanvasModule`,
    `cd backend && npm test`.
 
+## Diagnostics & Logging
+
+A correlation ID flows through every video request so we can grep one ID
+across all four log streams (iPad → backend → image pod → video pod).
+Source it from the iPad's `config.requestId` (already supported); the
+image pod echoes it in `frame_meta`; backend stamps the same ID onto the
+`video_request`; video pod echoes it on every `video_frame` /
+`video_complete` / `video_cancelled`.
+
+### Image pod (`server.py`)
+- Per generated frame, one INFO line including the new flag:
+  `frame: req=<id> queueEmpty=<bool> gen_ms=<ms> dropped_since_last=<n>`.
+- One INFO line on the false→true edge:
+  `queue drained: req=<id> last_generated_set=true`. Confirms the
+  trigger boundary cleanly.
+- On disconnect, summary: `session: frames=<n> queue_drained_count=<n>`.
+
+### Video pod (`video_server.py`, `video_pipeline.py`)
+- Pipeline load: `loaded LTXV: model=<id> dtype=<bf16> vram_used_gb=<n>
+  load_ms=<n>`.
+- Connection: `client connected: in_flight=<n>` /
+  `client disconnected: reason=<...>`.
+- Request: `video_request: req=<id> prompt='<truncated 60ch>'
+  image=<WxH> seed=<n>`.
+- Per decoded frame (every Nth, INFO):
+  `frame <i>/<total> decoded elapsed_ms=<ms>`.
+- Per step (DEBUG, gated on `LTXV_DEBUG=1` env so prod stays quiet):
+  `step <i>/<N> took_ms=<n>`.
+- Cancellation: `cancelled: req=<id> at_step=<i> elapsed_ms=<ms>`.
+- Completion: `complete: req=<id> frames=<N> gen_ms=<ms>
+  encode_ms=<ms> mp4_bytes=<n>`.
+- Pipeline error: full traceback + `req=<id>` so we can correlate.
+
+### Backend orchestrator
+- Distinct log prefixes for the two provisions: `[provision/image]` and
+  `[provision/video]`. Existing structured logger already includes
+  sessionKey — add a `pod_kind: 'image' | 'video'` field for filtering.
+- Image-pod provision failures stay `level=error` (fatal). Video-pod
+  failures `level=warn` (non-fatal) with a Sentry **breadcrumb**, not a
+  capture (would be too noisy).
+- Reaper: `[reaper] terminating session=<id> kind=<image|video>
+  idle_min=<n>`.
+- Reconcile on boot: `[reconcile] orphans found: image=<n> video=<n>`.
+
+### Backend `stream.ts`
+- One structured log per trigger:
+  `video_trigger: user=<id> req=<id> prompt_cached=<bool>
+   video_relay_connected=<bool>`.
+- Drop reasons logged distinctly:
+  - `video_skipped: reason=prompt_not_cached` (queueEmpty before iPad
+    sent its first `config` — bug-prone edge case worth alerting on).
+  - `video_skipped: reason=relay_disconnected`.
+  - `video_skipped: reason=already_in_flight` (defensive — should not
+    happen given queueEmpty semantics, but log if it does).
+- Cancel: `video_cancel_sent: user=<id> req=<id> elapsed_since_request_ms=<n>`.
+- Video relay close (uninitiated):
+  `video_relay_closed: user=<id> reason=<code> session_disabled=<bool>`.
+- Per-session counters emitted at WS close:
+  `session_close: user=<id> frames_relayed=<n> videos_triggered=<n>
+   videos_completed=<n> videos_cancelled=<n> videos_failed=<n>
+   duration_s=<n>`.
+
+### iPad
+- `StreamSession.captureLoop` — rate-limited (max 1/s) DEBUG line:
+  `frame skipped (strokeCount=<n> unchanged)` so we can verify the
+  dirty check without log spam.
+- `StreamSession` — INFO on every `video_*` event with bytes:
+  `[video] req=<id> type=<t> bytes=<n>`.
+- `AppCoordinator` — INFO on every `ResultState` transition:
+  `[result] <prev> → <next> req=<id>`. Lets us confirm the
+  `.streaming` ↔ `.videoStreaming` ↔ `.videoLooping` cycle.
+- `LoopingVideoView` — log `AVPlayerItem.status` changes,
+  `failedToPlayToEndTime` notifications, and any `AVPlayerLooper`
+  error. These are the only sources of "video shows but doesn't
+  loop" bugs.
+
+### Health endpoints (prod observability)
+- Image pod `/health` — add: `frames_total`, `queue_drained_count`,
+  `last_queue_empty_at` (ISO ts), `last_frame_gen_ms`.
+- Video pod `/health` — add: `videos_total`, `videos_cancelled`,
+  `videos_failed`, `last_gen_ms`, `last_encode_ms`, `vram_free_gb`.
+- Both surfaced via the orchestrator's existing health-poll path so
+  they show up in cost-monitor breadcrumbs.
+
+### Triage cookbook (paste into PR description)
+- **Trigger not firing**: grep image pod for `queue drained`. Absent =
+  iPad still sending; verify dirty check via the `frame skipped` line.
+- **Trigger firing, video not requested**: grep `stream.ts` for
+  `video_skipped`. The `reason=` says why.
+- **video_request sent, video pod silent**: hit video pod `/health`
+  directly; check `video_ready`. If false, model still loading.
+- **Generation starts, no MP4**: search video pod for `complete` for
+  that req=<id>. If only `cancelled`, look at backend for the
+  preceding `video_cancel_sent`. If neither, search for traceback.
+- **Looping playback stutters**: re-encode with `-movflags +faststart`
+  in the ffmpeg call, and check `LoopingVideoView` logs for buffering
+  events.
+- **iPad swaps to video too aggressively**: filter
+  `[result] streaming → videoStreaming` and verify each lines up with
+  exactly one `queue drained` on the image pod.
+
 ## Open risks / follow-ups
 
 - LTXV streaming-decode in current diffusers may not yield per-frame; if

--- a/documents/plans/drawing-animation.md
+++ b/documents/plans/drawing-animation.md
@@ -1,0 +1,238 @@
+# Plan: Drawing-stopped Video Animation (LTXV, separate pod)
+
+## Context
+
+When the user pauses drawing, Kiki's img2img pipeline is idle — the FLUX
+pod has nothing useful to do. We want to fill that idle time with a short
+video animation of the latest generated image (LTXV i2v), shown in the
+right pane until the user resumes drawing.
+
+A previous attempt co-loaded LTXV onto the FLUX pod. That branch
+(`claude/add-drawing-animation-cWJBV`, local) had memory and concurrency
+issues. **Decision: run video on a dedicated second pod per session.**
+This plan is written to be implemented fresh against `origin/main`.
+
+User-confirmed decisions:
+1. **Separate video pod**, provisioned alongside the image pod.
+2. **iPad protocol unchanged at the WS-level discriminator layer** (single
+   WS to backend); only adds new inbound `video_*` message types.
+3. **Silent fallback**: if the video pod fails to provision, image gen
+   continues normally. No error surfaced to the iPad.
+4. **Stream frames as they decode, then loop the final MP4** for smooth
+   playback.
+5. **Trigger logic**: pod-side `queueEmpty` flag on the image pod's
+   `frame_meta` preamble (rejected: backend counter — desyncs on
+   reconnects/drops; image hash — fragile to JPEG re-encode noise).
+
+## Architecture
+
+```
+iPad ──single WS──► Backend ──relay 1──► Image pod (FLUX, unchanged except
+                                          frame_meta gains queueEmpty flag)
+                       │              ◄── frame_meta{queueEmpty} + JPEG
+                       │
+                       └──relay 2──► Video pod (LTXV, NEW)
+                                  ◄── video_frame + JPEG (streaming),
+                                      then video_complete + MP4
+                       │
+                  iPad ◄──── relay 1 JPEG (img2img)
+                  iPad ◄──── relay 2 video_frame / _complete / _cancelled
+```
+
+Trigger flow:
+- iPad has dirty check (strokeCount unchanged → skip send). When user
+  stops drawing, the image pod's single-slot `latest_frame` buffer drains.
+- On the response immediately following a drained buffer, the image pod
+  sets `queueEmpty:true` in its `frame_meta` preamble.
+- Backend, seeing `queueEmpty:true`, captures that JPEG and forwards it
+  to the video pod as `{type:"video_request", image_b64, prompt}`.
+- Video pod streams frames + MP4 back. Backend forwards to iPad.
+- Any new sketch from the iPad → backend sends `{type:"video_cancel"}` to
+  the video pod, which aborts via `callback_on_step_end` and emits
+  `video_cancelled`. iPad swaps state back to `.streaming`.
+
+## Pod side
+
+### `flux-klein-server/server.py` (image pod — minimal change)
+- Extend `frame_meta` preamble to include `queueEmpty: latest_frame is None`
+  evaluated at frame-completion time. Single-line change in the existing
+  `frame_meta` JSON construction (~line 191 on origin/main).
+- Send `frame_meta` for *every* generated frame (currently only when
+  `requestId` is set). Backend needs the flag on every frame.
+
+### `flux-klein-server/video_server.py` (NEW)
+- FastAPI WS server, mirrors the structure of `server.py`.
+- Lifespan: load `LTXImageToVideoPipeline` (BF16, CUDA) once.
+- `/health` returns `{video_ready, model_id, vram_free_gb}`.
+- `/ws` per-connection state machine:
+  - On `{type:"video_request", image_b64, prompt, seed?}`:
+    1. Decode image → PIL.
+    2. Run pipeline with `callback_on_step_end` checking
+       `cancel_event.is_set()`. Emit each decoded frame as
+       `{type:"video_frame"}` + JPEG.
+    3. After generation: ffmpeg-encode frames → MP4 (H.264 yuv420p
+       CRF 28 ~24fps), send `{type:"video_complete"}` + MP4 bytes.
+  - On `{type:"video_cancel"}`: set `cancel_event`. Loop emits
+    `{type:"video_cancelled"}` and resets state.
+
+### `flux-klein-server/video_pipeline.py` (NEW)
+- `LtxvVideoPipeline` class: `load()`, `generate(image, prompt, seed,
+  cancel_event) -> Iterator[PIL.Image]`. Mirrors `FluxKleinPipeline` shape.
+
+### `flux-klein-server/requirements.txt`
+- `imageio[ffmpeg]`, `numpy`. Diffusers from git already pulled in.
+
+### Network volume / setup script
+- `backend/scripts/populate-volume.ts` — add LTXV model snapshot
+  download (~4GB).
+- Volume setup script — `apt-get install -y ffmpeg`.
+
+## Backend side
+
+### `backend/src/modules/orchestrator/orchestrator.ts`
+- Add `BOOT_DOCKER_ARGS_VIDEO` constant pointing at `video_server.py`
+  (mirrors `BOOT_DOCKER_ARGS` ~line 184).
+- Add `videoSessionKey(sessionId)` helper paralleling `sessionKey()`
+  (~line 224). Redis key suffix `:video`.
+- Add `provisionVideoPod(userId)` mirroring `provision()` but using
+  `BOOT_DOCKER_ARGS_VIDEO` and the video session key. Reuses the same
+  semaphore, reroll logic, error classification.
+- Add `getOrProvisionSession(userId)` that calls `getOrProvisionPod` and
+  `getOrProvisionVideoPod` in parallel. Returns
+  `{imagePodUrl, videoPodUrl?}`. **Video pod is best-effort**: if its
+  promise rejects, log + Sentry capture, return `videoPodUrl: null`.
+- Reaper iterates over both key prefixes; both pods terminate on idle.
+- Reconcile (boot) cleans `kiki-session-*` for both shapes.
+- **Quota/entitlement**: only the image-pod provision counts against the
+  user's quota. Video provisioning bypasses entitlement/rate-limit (it's
+  a side-effect of an already-allowed session).
+
+### `backend/src/routes/stream.ts`
+- After identity + quota, call `getOrProvisionSession(userId)`.
+- Open `StreamRelay` for the image pod (existing flow).
+- If `videoPodUrl != null`, open a second `StreamRelay` for the video pod.
+- Wire the trigger:
+  - On image-pod text frame: parse `frame_meta`. Stash
+    `nextBinaryQueueEmpty = parsed.queueEmpty`.
+  - On image-pod binary frame: forward to iPad as today. If
+    `nextBinaryQueueEmpty` was true AND video relay is connected,
+    forward the JPEG to the video pod as `video_request` with the
+    last-known prompt from the iPad's most recent `config` message.
+  - On iPad sketch frame: if a video request is in flight, send
+    `{type:"video_cancel"}` to the video pod.
+  - On video-pod text/binary: forward to iPad unchanged (as
+    `{type:"video_frame"}` / `{type:"video_complete"}` /
+    `{type:"video_cancelled"}` JSON-wrapped binaries to fit the
+    existing iOS WS workaround).
+- Both relays call `touch()` on activity.
+- Video relay close is silent: log + try once to reprovision lazily on
+  next `queueEmpty:true`. No iPad-visible error.
+
+### Config
+- Cache the latest `prompt` per-connection in stream.ts (it already
+  arrives on `config` messages from the iPad). Used to populate the
+  `video_request`.
+
+## iPad side
+
+### `ios/Kiki/App/StreamSession.swift`
+- Capture loop adds dirty check: track `lastSentStrokeCount`. Skip the
+  send when `snapshot.strokeCount == lastSentStrokeCount` and config is
+  unchanged. On config change, reset `lastSentStrokeCount = nil`.
+  (Reuses existing `SketchSnapshot.strokeCount` already incremented in
+  `MetalCanvasView` on stroke/erase/undo/redo/clear/background-change.)
+
+### `ios/Packages/NetworkModule/.../StreamWebSocketClient.swift`
+- Add `type` discriminators: `video_frame`, `video_complete`,
+  `video_cancelled`.
+- Expose `videoEvents: AsyncStream<VideoEvent>` alongside the existing
+  frame stream. `VideoEvent` cases: `frame(UIImage)`,
+  `complete(mp4Data: Data)`, `cancelled`.
+
+### `ios/Packages/ResultModule/.../ResultState.swift`
+- Add cases:
+  - `videoStreaming(latestFrame: UIImage, fallback: UIImage)`
+  - `videoLooping(mp4URL: URL, fallback: UIImage)`
+- `fallback` keeps Constraint #2 (never clear the right pane) if anything
+  goes wrong mid-video.
+
+### `ios/Packages/ResultModule/.../ResultView.swift`
+- Render `videoStreaming` like `.streaming` but pinned to `latestFrame`.
+- For `videoLooping`, embed a `LoopingVideoView` (UIViewRepresentable
+  wrapping `AVQueuePlayer` + `AVPlayerLooper` with a local MP4 URL,
+  `videoGravity = .resizeAspect`).
+
+### `ios/Kiki/App/AppCoordinator.swift`
+- Subscribe to `session.videoEvents`:
+  - `.frame(img)` → set `resultState = .videoStreaming(img, fallback: lastStill)`
+  - `.complete(data)` → write MP4 to `FileManager.default.temporaryDirectory`,
+    set `resultState = .videoLooping(url, fallback: lastStill)`
+  - `.cancelled` → revert to `.streaming(lastStill, frameCount: ...)`
+- On any new img2img frame received while in a video state → revert to
+  `.streaming` and (if previously `.videoLooping`) delete the temp MP4.
+- On `stopStream()`: clean up temp MP4 files.
+
+## Files to modify / create
+
+| File | Change |
+|------|--------|
+| `flux-klein-server/server.py` | add `queueEmpty` to `frame_meta`; emit on every frame |
+| `flux-klein-server/video_server.py` | NEW — LTXV WebSocket server |
+| `flux-klein-server/video_pipeline.py` | NEW — LTXV pipeline wrapper |
+| `flux-klein-server/requirements.txt` | + `imageio[ffmpeg]`, `numpy` |
+| `backend/scripts/populate-volume.ts` (or equiv.) | + LTXV weights |
+| Volume setup script | + `apt install ffmpeg` |
+| `backend/src/modules/orchestrator/orchestrator.ts` | `BOOT_DOCKER_ARGS_VIDEO`, `provisionVideoPod`, `getOrProvisionSession`, dual-key reaper/reconcile |
+| `backend/src/routes/stream.ts` | second relay; `frame_meta.queueEmpty`-driven video trigger; cache prompt; cancel on new sketch |
+| `ios/Kiki/App/StreamSession.swift` | dirty check on `strokeCount`; expose `videoEvents` |
+| `ios/Packages/NetworkModule/.../StreamWebSocketClient.swift` | parse `video_*` types |
+| `ios/Packages/ResultModule/.../ResultState.swift` | `.videoStreaming`, `.videoLooping` |
+| `ios/Packages/ResultModule/.../ResultView.swift` | `LoopingVideoView` (AVPlayerLooper) |
+| `ios/Kiki/App/AppCoordinator.swift` | wire video events; revert on new still; temp file cleanup |
+
+## Existing utilities to reuse
+
+- `SketchSnapshot.strokeCount` (`ios/Packages/CanvasModule/.../SketchSnapshot.swift`) — dirty signal.
+- `latest_frame` single-slot buffer (`flux-klein-server/server.py`) — exact "no new sketch" signal.
+- `StreamRelay` (`backend/src/modules/relay/streamRelay.ts`) — second relay reuses it as-is.
+- `provision()` and provisioning machinery (`orchestrator.ts`) — `provisionVideoPod` parallels it.
+- `pipeline.get_info()` health pattern — mirror for LTXV.
+- `ResultState`'s `previousImage` convention — extend with `fallback`.
+
+## Verification
+
+1. **Both pods warm**: provision a session, hit each pod's `/health`.
+   Image returns `quantization:"nvfp4"`, video returns `video_ready:true`.
+2. **Trigger fires**: draw, stop. Backend log shows
+   `frame_meta queueEmpty:true → video_request`. iPad swaps to
+   `.videoStreaming` within ~1s of stopping (LTXV first frame), then
+   `.videoLooping` once MP4 lands.
+3. **Cancellation**: start drawing during video playback. iPad immediately
+   reverts to `.streaming`. Video pod log shows `cancelled`.
+4. **Once-per-still**: stop drawing; one video plays + loops; no second
+   video kicks off (no new `queueEmpty:true` until a new image is
+   generated).
+5. **Silent fallback**: force `provisionVideoPod` to fail (bad model ID).
+   Image gen still works end-to-end. Backend logs the failure once;
+   iPad sees no error.
+6. **Dirty check**: simulator log shows frame counter plateaus when
+   user stops drawing. Changing the prompt or style forces one resend.
+7. **Resource cleanup**: end session, both pods terminate via reaper.
+   Redis keys for both suffixes deleted. Temp MP4 files removed on iPad.
+8. **Existing test suites pass**: `xcodebuild test`,
+   `swift test --package-path ios/Packages/CanvasModule`,
+   `cd backend && npm test`.
+
+## Open risks / follow-ups
+
+- LTXV streaming-decode in current diffusers may not yield per-frame; if
+  not, time-to-first-playback degrades from "first decoded frame" to
+  "after generation completes". Plausibly still <3–4s on a 5090 at small
+  resolutions and few steps. Acceptable for v1; revisit if not.
+- ffmpeg subprocess adds ~200–500ms encode. Acceptable.
+- Two pods per session ~2× the spot-cost. Idle reaper at 10min still
+  bounds cost.
+- Content safety: video output must pass NSFW filter before external
+  TestFlight (Constraint #5). Out of scope here, follow-up PR.
+- Video-specific prompt suffix: deferred. Easy to add later in the
+  `video_request` builder in stream.ts.

--- a/flux-klein-server/config.py
+++ b/flux-klein-server/config.py
@@ -30,3 +30,30 @@ DTYPE = os.getenv("FLUX_DTYPE", "bfloat16")  # "bfloat16" or "float16"
 USE_NVFP4 = os.getenv("FLUX_USE_NVFP4", "1") == "1"
 NVFP4_REPO = os.getenv("FLUX_NVFP4_REPO", "black-forest-labs/FLUX.2-klein-4b-nvfp4")
 NVFP4_FILENAME = os.getenv("FLUX_NVFP4_FILENAME", "flux-2-klein-4b-nvfp4.safetensors")
+
+# ─── LTXV (video pod) ───────────────────────────────────────────────────────
+# The video pod runs LTXImageToVideoPipeline with the 0.9.8 distilled
+# transformer overwritten on top of the 0.9.5 base (VAE / text encoder /
+# scheduler come from base). Must match the populate-volume.ts download
+# constants so the pod can run fully offline.
+LTXV_BASE_REPO = os.getenv("LTXV_BASE_REPO", "Lightricks/LTX-Video-0.9.5")
+LTXV_TRANSFORMER_REPO = os.getenv("LTXV_TRANSFORMER_REPO", "Lightricks/LTX-Video")
+LTXV_TRANSFORMER_FILE = os.getenv(
+    "LTXV_TRANSFORMER_FILE", "ltxv-2b-0.9.8-distilled-fp8.safetensors"
+)
+# Generation parameters. Defaults sized for ~2 s video at 24 fps with
+# headroom for sub-3 s end-to-end on a 5090: keeps the right pane
+# responsive when the user resumes drawing.
+LTXV_WIDTH = int(os.getenv("LTXV_WIDTH", "704"))
+LTXV_HEIGHT = int(os.getenv("LTXV_HEIGHT", "480"))
+LTXV_NUM_FRAMES = int(os.getenv("LTXV_NUM_FRAMES", "49"))
+LTXV_STEPS = int(os.getenv("LTXV_STEPS", "8"))
+LTXV_FPS = int(os.getenv("LTXV_FPS", "24"))
+LTXV_OUTPUT_JPEG_QUALITY = int(os.getenv("LTXV_OUTPUT_QUALITY", "80"))
+# Negative prompt — slight quality bump per LTX docs.
+LTXV_NEGATIVE_PROMPT = os.getenv(
+    "LTXV_NEGATIVE_PROMPT",
+    "worst quality, inconsistent motion, blurry, jittery, distorted",
+)
+# Toggle for verbose per-step logging in the video pipeline. Off by default.
+LTXV_DEBUG = os.getenv("LTXV_DEBUG", "0") == "1"

--- a/flux-klein-server/requirements.txt
+++ b/flux-klein-server/requirements.txt
@@ -20,3 +20,8 @@ fastapi>=0.108.0
 uvicorn[standard]>=0.25.0
 websockets>=12.0
 Pillow>=10.0.0
+
+# Video pod (LTXV) — bundled ffmpeg binary keeps the pod self-contained,
+# no apt install needed. imageio-ffmpeg pulls a static ffmpeg into the
+# venv at install time. ~30 MB.
+imageio-ffmpeg>=0.4.9

--- a/flux-klein-server/server.py
+++ b/flux-klein-server/server.py
@@ -7,7 +7,11 @@ Protocol:
 
   Server -> Client:
     - Text frame (JSON): { "type": "status", "status": "ready" | "warmup" | "error", "message": "..." }
-    - Text frame (JSON): { "type": "frame_meta", "requestId": "..." }  (only when cfg has requestId, immediately precedes binary)
+    - Text frame (JSON): { "type": "frame_meta", "requestId": "..."|null, "queueEmpty": <bool> }
+        Always sent immediately before each generated binary. `queueEmpty`
+        is true when the input buffer was empty at frame-completion time —
+        the backend uses this as the trigger to dispatch the just-sent
+        image to the video pod for animation.
     - Binary frame: Generated JPEG bytes
 
 Frame dropping:
@@ -18,9 +22,9 @@ Frame dropping:
 Correlation:
   `requestId` lets the client route responses to specific requests (used by
   the style-preview picker). The value is snapshotted into cfg at generation
-  start so it survives config updates that arrive mid-generation. Responses
-  for normal streaming frames omit the requestId and the `frame_meta`
-  preamble, preserving the binary-only wire shape on that path.
+  start so it survives config updates that arrive mid-generation. The same
+  ID propagates to the video pod via the backend, so a single grep matches
+  the full lifecycle.
 """
 from __future__ import annotations
 
@@ -105,12 +109,20 @@ async def websocket_stream(ws: WebSocket):
     frames_received = 0
     frames_processed = 0
     frames_dropped = 0
+    # Per-send dropped counter for the diagnostic log; reset after each emit.
+    frames_dropped_since_last_send = 0
+    # Count of false->true transitions on queueEmpty (i.e. distinct trigger
+    # opportunities for the video pod). Useful in disconnect summary + /health.
+    queue_drained_count = 0
+    # Last queueEmpty value seen, for edge detection.
+    prev_queue_empty: bool | None = None
     session_start = time.time()
     done = False
 
     async def receive_loop():
         """Read messages from the client. Keep only the latest binary frame."""
         nonlocal latest_frame, frames_received, frames_dropped, done, current_config
+        nonlocal frames_dropped_since_last_send
 
         try:
             while not done:
@@ -152,6 +164,7 @@ async def websocket_stream(ws: WebSocket):
                 if "bytes" in message:
                     if latest_frame is not None:
                         frames_dropped += 1
+                        frames_dropped_since_last_send += 1
                     latest_frame = message["bytes"]
                     frames_received += 1
                     frame_event.set()
@@ -167,6 +180,7 @@ async def websocket_stream(ws: WebSocket):
     async def process_loop():
         """Process the latest frame whenever one is available."""
         nonlocal latest_frame, frames_processed, done
+        nonlocal frames_dropped_since_last_send, queue_drained_count, prev_queue_empty
 
         while not done:
             await frame_event.wait()
@@ -183,16 +197,39 @@ async def websocket_stream(ws: WebSocket):
 
             try:
                 cfg = dict(current_config)
+                gen_start = time.time()
                 result_jpeg = await asyncio.to_thread(_process_frame, jpeg_data, cfg)
+                gen_ms = int((time.time() - gen_start) * 1000)
                 if not done:
                     request_id = cfg.get("requestId")
-                    if request_id is not None:
-                        await ws.send_text(json.dumps({
-                            "type": "frame_meta",
-                            "requestId": request_id,
-                        }))
+                    # Evaluated at frame-completion time: if no new frame has
+                    # arrived during generation, the iPad has stopped drawing
+                    # and this image is eligible for video animation.
+                    queue_empty = latest_frame is None
+                    await ws.send_text(json.dumps({
+                        "type": "frame_meta",
+                        "requestId": request_id,
+                        "queueEmpty": queue_empty,
+                    }))
                     await ws.send_bytes(result_jpeg)
                     frames_processed += 1
+
+                    # Edge log: false -> true transition. This is the moment
+                    # the backend will dispatch the just-sent image to the
+                    # video pod. Single grep target during triage.
+                    if queue_empty and prev_queue_empty is not True:
+                        queue_drained_count += 1
+                        logger.info(
+                            "queue drained: req=%s last_generated_set=true",
+                            request_id,
+                        )
+                    prev_queue_empty = queue_empty
+
+                    logger.info(
+                        "frame: req=%s queueEmpty=%s gen_ms=%d dropped_since_last=%d",
+                        request_id, queue_empty, gen_ms, frames_dropped_since_last_send,
+                    )
+                    frames_dropped_since_last_send = 0
             except Exception as e:
                 logger.error("Frame processing error: %s", e, exc_info=True)
                 if not done:
@@ -214,8 +251,8 @@ async def websocket_stream(ws: WebSocket):
         elapsed = time.time() - session_start
         fps = frames_processed / elapsed if elapsed > 0 else 0
         logger.info(
-            "Client %d disconnected. Received %d, processed %d, dropped %d, %.1f FPS over %.1fs",
-            client_id, frames_received, frames_processed, frames_dropped, fps, elapsed,
+            "Client %d disconnected. Received %d, processed %d, dropped %d, queue_drained %d, %.1f FPS over %.1fs",
+            client_id, frames_received, frames_processed, frames_dropped, queue_drained_count, fps, elapsed,
         )
 
 

--- a/flux-klein-server/test_client.py
+++ b/flux-klein-server/test_client.py
@@ -65,35 +65,46 @@ async def run_test(args):
             await ws.send(jpeg_data)
 
             try:
+                # Server sends frame_meta (text) then binary, in that order,
+                # for every generated frame.
+                meta_msg = await asyncio.wait_for(ws.recv(), timeout=30.0)
+                assert isinstance(meta_msg, str), (
+                    f"expected frame_meta text before binary, got {type(meta_msg)}"
+                )
+                meta = json.loads(meta_msg)
+                if meta.get("type") == "status" and meta.get("status") == "error":
+                    print(f"\nServer error: {meta.get('message')}")
+                    continue
+                assert meta.get("type") == "frame_meta", f"unexpected: {meta}"
+                assert "queueEmpty" in meta, "frame_meta missing queueEmpty"
+
                 response = await asyncio.wait_for(ws.recv(), timeout=30.0)
+                assert isinstance(response, bytes), (
+                    f"expected binary after frame_meta, got {type(response)}"
+                )
 
-                if isinstance(response, bytes):
-                    results_received += 1
-                    size_kb = len(response) / 1024
-                    elapsed = time.time() - t_start
-                    fps = results_received / elapsed if elapsed > 0 else 0
+                results_received += 1
+                size_kb = len(response) / 1024
+                elapsed = time.time() - t_start
+                fps = results_received / elapsed if elapsed > 0 else 0
 
-                    if num_frames == 1:
-                        output_path = "output.jpg"
-                        with open(output_path, "wb") as f:
-                            f.write(response)
-                        print(f"Result saved to {output_path} ({size_kb:.1f} KB)")
-                        result_img = Image.open(io.BytesIO(response))
-                        print(f"Output resolution: {result_img.size}")
-                    else:
-                        print(
-                            f"Frame {i+1}/{num_frames}: "
-                            f"received {size_kb:.1f} KB, "
-                            f"{fps:.1f} FPS avg",
-                            end="\r",
-                        )
-
-                elif isinstance(response, str):
-                    data = json.loads(response)
-                    if data.get("type") == "status" and data.get("status") == "error":
-                        print(f"\nServer error: {data.get('message')}")
-                    else:
-                        print(f"\nServer message: {data}")
+                if num_frames == 1:
+                    output_path = "output.jpg"
+                    with open(output_path, "wb") as f:
+                        f.write(response)
+                    print(
+                        f"Result saved to {output_path} ({size_kb:.1f} KB) "
+                        f"queueEmpty={meta['queueEmpty']} reqId={meta.get('requestId')}"
+                    )
+                    result_img = Image.open(io.BytesIO(response))
+                    print(f"Output resolution: {result_img.size}")
+                else:
+                    print(
+                        f"Frame {i+1}/{num_frames}: "
+                        f"{size_kb:.1f} KB, {fps:.1f} FPS avg, "
+                        f"queueEmpty={meta['queueEmpty']}",
+                        end="\r",
+                    )
 
             except asyncio.TimeoutError:
                 print(f"\nTimeout waiting for frame {i+1}")

--- a/flux-klein-server/test_video_client.py
+++ b/flux-klein-server/test_video_client.py
@@ -3,10 +3,10 @@
 Usage:
     python test_video_client.py --url ws://localhost:8766/ws --image still.jpg --prompt "a cat dancing"
 
-Asserts the wire protocol matches video_server.py: receives frame_meta-style
-status, then a sequence of (video_frame text + JPEG binary) pairs, then
-(video_complete text + MP4 binary). Saves the MP4 + last frame for
-visual inspection.
+Asserts the wire protocol matches video_server.py: an initial
+{type: "status", status: "ready"|"warmup"} JSON, then a sequence of
+(video_frame text + JPEG binary) pairs, then a (video_complete text +
+MP4 binary) pair. Saves the MP4 + last frame for visual inspection.
 """
 import argparse
 import asyncio

--- a/flux-klein-server/test_video_client.py
+++ b/flux-klein-server/test_video_client.py
@@ -1,0 +1,115 @@
+"""Test client for the LTXV video pod WebSocket server.
+
+Usage:
+    python test_video_client.py --url ws://localhost:8766/ws --image still.jpg --prompt "a cat dancing"
+
+Asserts the wire protocol matches video_server.py: receives frame_meta-style
+status, then a sequence of (video_frame text + JPEG binary) pairs, then
+(video_complete text + MP4 binary). Saves the MP4 + last frame for
+visual inspection.
+"""
+import argparse
+import asyncio
+import base64
+import io
+import json
+import time
+
+import websockets
+from PIL import Image
+
+
+async def run_test(args):
+    print(f"Connecting to {args.url}...")
+
+    async with websockets.connect(args.url, max_size=50 * 1024 * 1024) as ws:
+        # Initial status
+        msg = await ws.recv()
+        status = json.loads(msg)
+        print(f"Server status: {status}")
+        if status.get("status") != "ready":
+            print("Waiting for server to be ready...")
+            while True:
+                msg = await ws.recv()
+                status = json.loads(msg)
+                if status.get("status") == "ready":
+                    break
+
+        # Build a video_request
+        image = Image.open(args.image).convert("RGB")
+        buf = io.BytesIO()
+        image.save(buf, format="JPEG", quality=85)
+        image_b64 = base64.b64encode(buf.getvalue()).decode("ascii")
+
+        request_id = f"test-{int(time.time())}"
+        await ws.send(json.dumps({
+            "type": "video_request",
+            "requestId": request_id,
+            "image_b64": image_b64,
+            "prompt": args.prompt,
+            "seed": args.seed,
+        }))
+        print(f"Sent video_request: req={request_id}, prompt='{args.prompt}', image={image.size}")
+
+        frames_received = 0
+        last_frame_jpeg = None
+        mp4_bytes = None
+        t_start = time.time()
+
+        while True:
+            msg = await asyncio.wait_for(ws.recv(), timeout=120.0)
+            if isinstance(msg, str):
+                meta = json.loads(msg)
+                t = meta.get("type")
+                if t == "video_frame":
+                    # Next message is the JPEG binary
+                    binary = await ws.recv()
+                    assert isinstance(binary, (bytes, bytearray)), f"expected bytes, got {type(binary)}"
+                    frames_received += 1
+                    last_frame_jpeg = bytes(binary)
+                    print(f"  frame {meta.get('index')}/{meta.get('total')}: {len(binary)} bytes "
+                          f"(elapsed {time.time() - t_start:.1f}s)")
+                elif t == "video_complete":
+                    binary = await ws.recv()
+                    assert isinstance(binary, (bytes, bytearray)), f"expected MP4 bytes, got {type(binary)}"
+                    mp4_bytes = bytes(binary)
+                    print(f"  video_complete: frames={meta.get('frames')} fps={meta.get('fps')} "
+                          f"genMs={meta.get('genMs')} encodeMs={meta.get('encodeMs')} "
+                          f"mp4_bytes={len(mp4_bytes)}")
+                    break
+                elif t == "video_cancelled":
+                    print(f"  video_cancelled: atStep={meta.get('atStep')} error={meta.get('error')}")
+                    break
+                else:
+                    print(f"  unexpected: {meta}")
+            else:
+                print(f"  unexpected binary (no preceding text): {len(msg)} bytes")
+
+    elapsed = time.time() - t_start
+    print(f"\nResults:")
+    print(f"  Frames received: {frames_received}")
+    print(f"  Total time:      {elapsed:.2f}s")
+
+    if last_frame_jpeg:
+        with open("video_last_frame.jpg", "wb") as f:
+            f.write(last_frame_jpeg)
+        print(f"  Last frame -> video_last_frame.jpg ({len(last_frame_jpeg)} bytes)")
+    if mp4_bytes:
+        with open("output.mp4", "wb") as f:
+            f.write(mp4_bytes)
+        print(f"  MP4         -> output.mp4 ({len(mp4_bytes)} bytes)")
+
+
+def main():
+    parser = argparse.ArgumentParser(description="LTXV video pod test client")
+    parser.add_argument("--url", default="ws://localhost:8766/ws")
+    parser.add_argument("--image", required=True, help="Input still image (JPEG/PNG)")
+    parser.add_argument("--prompt", default="a still scene", help="Animation prompt")
+    parser.add_argument("--seed", type=int, default=42)
+    args = parser.parse_args()
+
+    asyncio.run(run_test(args))
+
+
+if __name__ == "__main__":
+    main()

--- a/flux-klein-server/video_pipeline.py
+++ b/flux-klein-server/video_pipeline.py
@@ -1,0 +1,183 @@
+"""LTX-Video 2B (0.9.8 distilled) image-to-video pipeline.
+
+Loads the 0.9.5 base for VAE/text-encoder/scheduler and overwrites the
+transformer with the 0.9.8 distilled single-file checkpoint — same pattern
+FluxKleinPipeline uses for NVFP4. The base 0.9.5 transformer weights are
+deliberately NOT on the volume (see backend/scripts/populate-volume.ts);
+we sidestep that by loading the distilled transformer first via
+``from_single_file`` and injecting it into ``from_pretrained`` so the
+pipeline's own transformer load is skipped.
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+import time
+from typing import Callable
+
+import torch
+from PIL import Image
+
+import config
+
+logger = logging.getLogger(__name__)
+
+
+class CancelledError(Exception):
+    """Raised inside the diffusion loop when the backend signals cancel.
+
+    Bubbles up out of ``self.pipe(...)``; ``generate()`` catches it and
+    returns ``None`` so the caller can emit a ``video_cancelled`` frame
+    cleanly.
+    """
+
+
+class LtxvVideoPipeline:
+    """Wraps ``LTXImageToVideoPipeline`` for the idle-state animation flow.
+
+    Single-instance, single-GPU. Calls are serialized through ``_lock`` so
+    the WebSocket layer can fire-and-forget without worrying about overlap.
+    """
+
+    def __init__(self) -> None:
+        self.pipe = None
+        self._ready = False
+        self._lock = threading.Lock()
+        self._load_ms: int = 0
+
+    @property
+    def ready(self) -> bool:
+        return self._ready
+
+    def load(self) -> None:
+        logger.info(
+            "Loading LTXV: base=%s transformer=%s/%s",
+            config.LTXV_BASE_REPO,
+            config.LTXV_TRANSFORMER_REPO,
+            config.LTXV_TRANSFORMER_FILE,
+        )
+        t0 = time.time()
+
+        from diffusers import LTXImageToVideoPipeline, LTXVideoTransformer3DModel
+        from huggingface_hub import hf_hub_download
+
+        # Distilled transformer — single-file checkpoint. Loading via
+        # ``from_single_file`` lets diffusers infer the architecture from
+        # the safetensors metadata without needing the 0.9.5 transformer
+        # weights as a fallback (which the volume doesn't have).
+        transformer_path = hf_hub_download(
+            repo_id=config.LTXV_TRANSFORMER_REPO,
+            filename=config.LTXV_TRANSFORMER_FILE,
+        )
+        logger.info("Loading transformer single-file: %s", transformer_path)
+        transformer = LTXVideoTransformer3DModel.from_single_file(
+            transformer_path,
+            torch_dtype=torch.bfloat16,
+        )
+
+        # Base pipeline — passing transformer= bypasses transformer load
+        # from the base repo (which is intentional: those weights aren't
+        # on the volume).
+        self.pipe = LTXImageToVideoPipeline.from_pretrained(
+            config.LTXV_BASE_REPO,
+            transformer=transformer,
+            torch_dtype=torch.bfloat16,
+        )
+        self.pipe.to("cuda")
+
+        logger.info("LTXV loaded in %.1fs", time.time() - t0)
+
+        # Warmup — first call has lazy CUDA kernel compilation. Doing it
+        # here keeps the user-visible first video latency clean.
+        logger.info("LTXV warmup...")
+        t1 = time.time()
+        warmup_image = Image.new("RGB", (config.LTXV_WIDTH, config.LTXV_HEIGHT), (128, 128, 128))
+        with self._lock:
+            _ = self.pipe(
+                image=warmup_image,
+                prompt="warmup",
+                negative_prompt=config.LTXV_NEGATIVE_PROMPT,
+                width=config.LTXV_WIDTH,
+                height=config.LTXV_HEIGHT,
+                num_frames=config.LTXV_NUM_FRAMES,
+                num_inference_steps=config.LTXV_STEPS,
+                guidance_scale=1.0,
+                generator=torch.Generator(device="cuda").manual_seed(0),
+            )
+        logger.info("LTXV warmup done (%.1fs)", time.time() - t1)
+
+        self._load_ms = int((time.time() - t0) * 1000)
+        self._ready = True
+
+    def generate(
+        self,
+        image: Image.Image,
+        prompt: str,
+        seed: int | None,
+        is_cancelled: Callable[[], bool],
+    ) -> list[Image.Image] | None:
+        """Generate a video from ``image``+``prompt``. Returns the decoded
+        frame list, or ``None`` if cancelled mid-generation.
+
+        ``is_cancelled`` is polled in a step callback; raising inside the
+        callback is what actually aborts the diffusion loop.
+        """
+        generator = self._make_generator(seed)
+
+        def _step_cb(pipe, step, timestep, callback_kwargs):  # noqa: ANN001
+            if is_cancelled():
+                # Raising propagates out of pipe.__call__ — we catch it
+                # below. Diffusers swallows callback return values but
+                # propagates exceptions, so this is the supported way to
+                # exit early.
+                raise CancelledError(f"cancel at step {step}")
+            if config.LTXV_DEBUG:
+                logger.debug("ltxv step %d ts=%s", step, timestep)
+            return callback_kwargs
+
+        with self._lock:
+            try:
+                result = self.pipe(
+                    image=image,
+                    prompt=prompt or "",
+                    negative_prompt=config.LTXV_NEGATIVE_PROMPT,
+                    width=config.LTXV_WIDTH,
+                    height=config.LTXV_HEIGHT,
+                    num_frames=config.LTXV_NUM_FRAMES,
+                    num_inference_steps=config.LTXV_STEPS,
+                    guidance_scale=1.0,
+                    generator=generator,
+                    callback_on_step_end=_step_cb,
+                )
+            except CancelledError as e:
+                logger.info("LTXV cancelled (%s)", e)
+                return None
+
+        # result.frames is List[List[PIL.Image.Image]] — one per batch
+        # element; we ran a single prompt so the outer list has length 1.
+        frames = result.frames[0]
+        return frames
+
+    def _make_generator(self, seed: int | None) -> torch.Generator | None:
+        if seed is not None:
+            return torch.Generator(device="cuda").manual_seed(seed)
+        return None
+
+    def get_info(self) -> dict:
+        gpu_name = torch.cuda.get_device_name(0) if torch.cuda.is_available() else "none"
+        vram_free = 0.0
+        if torch.cuda.is_available():
+            vram_free = torch.cuda.mem_get_info()[0] / (1024**3)
+        return {
+            "video_ready": self._ready,
+            "model": f"{config.LTXV_TRANSFORMER_REPO}/{config.LTXV_TRANSFORMER_FILE}",
+            "base": config.LTXV_BASE_REPO,
+            "resolution": f"{config.LTXV_WIDTH}x{config.LTXV_HEIGHT}",
+            "num_frames": config.LTXV_NUM_FRAMES,
+            "steps": config.LTXV_STEPS,
+            "fps": config.LTXV_FPS,
+            "gpu": gpu_name,
+            "vram_free_gb": round(vram_free, 2),
+            "load_ms": self._load_ms,
+        }

--- a/flux-klein-server/video_server.py
+++ b/flux-klein-server/video_server.py
@@ -185,24 +185,43 @@ async def websocket_video(ws: WebSocket):
         # Encode MP4 via the bundled ffmpeg binary. Using a subprocess
         # rather than imageio.mimwrite() because we want explicit control
         # over codec / pixel format / faststart for smooth iOS playback.
-        encode_t0 = time.time()
-        mp4_bytes = await asyncio.to_thread(_encode_mp4, frames, config.LTXV_FPS)
-        encode_ms = int((time.time() - encode_t0) * 1000)
+        # Wrap encode + send in try/except so a failure here emits
+        # video_cancelled (visible to backend + iPad) instead of silently
+        # dying — the create_task future has nobody awaiting it.
+        try:
+            encode_t0 = time.time()
+            mp4_bytes = await asyncio.to_thread(_encode_mp4, frames, config.LTXV_FPS)
+            encode_ms = int((time.time() - encode_t0) * 1000)
 
-        videos_total += 1
-        logger.info(
-            "complete: req=%s frames=%d gen_ms=%d encode_ms=%d mp4_bytes=%d",
-            request_id, len(frames), gen_ms, encode_ms, len(mp4_bytes),
-        )
-        await ws.send_text(json.dumps({
-            "type": "video_complete",
-            "requestId": request_id,
-            "fps": config.LTXV_FPS,
-            "frames": len(frames),
-            "genMs": gen_ms,
-            "encodeMs": encode_ms,
-        }))
-        await ws.send_bytes(mp4_bytes)
+            videos_total += 1
+            logger.info(
+                "complete: req=%s frames=%d gen_ms=%d encode_ms=%d mp4_bytes=%d",
+                request_id, len(frames), gen_ms, encode_ms, len(mp4_bytes),
+            )
+            await ws.send_text(json.dumps({
+                "type": "video_complete",
+                "requestId": request_id,
+                "fps": config.LTXV_FPS,
+                "frames": len(frames),
+                "genMs": gen_ms,
+                "encodeMs": encode_ms,
+            }))
+            await ws.send_bytes(mp4_bytes)
+        except Exception as e:  # noqa: BLE001
+            videos_failed += 1
+            logger.error(
+                "encode/send failed: req=%s err=%s", request_id, e, exc_info=True,
+            )
+            try:
+                await ws.send_text(json.dumps({
+                    "type": "video_cancelled",
+                    "requestId": request_id,
+                    "atStep": current_step_count["step"],
+                    "error": f"encode_or_send_failed: {e}",
+                }))
+            except Exception:  # noqa: BLE001
+                # WS already broken; nothing else to do.
+                pass
 
     try:
         while True:
@@ -307,13 +326,13 @@ def _encode_mp4(frames: list[Image.Image], fps: int) -> bytes:
         "-f", "mp4",
         "pipe:1",
     ]
+    # NOTE: must use communicate(input=...) — sequential stdin-then-stdout
+    # deadlocks when ffmpeg's stdout fills the 64 KB pipe buffer (a 100-300 KB
+    # MP4 will). communicate() does the IO concurrently via threads.
+    raw_input = b"".join(f.tobytes() for f in frames)
     proc = subprocess.Popen(cmd, stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-    assert proc.stdin is not None and proc.stdout is not None
     try:
-        for f in frames:
-            proc.stdin.write(f.tobytes())
-        proc.stdin.close()
-        out, err = proc.communicate(timeout=30)
+        out, err = proc.communicate(input=raw_input, timeout=30)
         if proc.returncode != 0:
             raise RuntimeError(f"ffmpeg failed: rc={proc.returncode} stderr={err.decode('utf-8', 'replace')[:500]}")
         return out

--- a/flux-klein-server/video_server.py
+++ b/flux-klein-server/video_server.py
@@ -1,0 +1,331 @@
+"""LTXV video pod WebSocket server.
+
+Protocol (backend -> pod):
+    - Text frame (JSON):
+        { "type": "video_request",
+          "requestId": "...",
+          "image_b64": "<JPEG, base64>",
+          "prompt": "...",
+          "seed": <int|null> }
+    - Text frame (JSON):
+        { "type": "video_cancel", "requestId": "..." }
+
+Protocol (pod -> backend):
+    - Text frame (JSON): { "type": "status", "status": "ready"|"warmup"|"error", "message": "..." }
+    - Per decoded frame: text frame { "type": "video_frame", "requestId": "..." } then binary JPEG.
+    - On completion: text frame { "type": "video_complete", "requestId": "...",
+                                  "fps": <int>, "frames": <int> } then binary MP4.
+    - On cancel: text frame { "type": "video_cancelled", "requestId": "...", "atStep": <int|null> }.
+
+One in-flight generation per connection. A new ``video_request`` cancels
+any running generation before starting (defensive — the backend already
+serializes via the queueEmpty trigger, but new sketches can interleave).
+
+The pipeline is loaded once at process start (``lifespan``) and shared
+across connections via an ``asyncio.Lock`` inside the pipeline class.
+"""
+from __future__ import annotations
+
+import asyncio
+import base64
+import io
+import json
+import logging
+import subprocess
+import time
+from contextlib import asynccontextmanager
+from threading import Event
+
+import imageio_ffmpeg
+import uvicorn
+from fastapi import FastAPI, WebSocket, WebSocketDisconnect
+from PIL import Image
+
+import config
+from video_pipeline import LtxvVideoPipeline
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
+)
+logger = logging.getLogger(__name__)
+
+video_pipeline = LtxvVideoPipeline()
+
+
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    logger.info("Starting LTXV video server...")
+    video_pipeline.load()
+    yield
+    logger.info("Shutting down.")
+
+
+app = FastAPI(lifespan=lifespan)
+
+
+@app.get("/health")
+async def health():
+    info = video_pipeline.get_info()
+    return {"status": "ok" if video_pipeline.ready else "loading", **info}
+
+
+@app.websocket("/ws")
+async def websocket_video(ws: WebSocket):
+    await ws.accept()
+    client_id = id(ws)
+    logger.info("client connected: id=%d", client_id)
+
+    if video_pipeline.ready:
+        await ws.send_text(json.dumps({"type": "status", "status": "ready"}))
+    else:
+        await ws.send_text(json.dumps({"type": "status", "status": "warmup"}))
+        while not video_pipeline.ready:
+            await asyncio.sleep(0.5)
+        await ws.send_text(json.dumps({"type": "status", "status": "ready"}))
+
+    # Per-connection state
+    current_task: asyncio.Task | None = None
+    current_request_id: str | None = None
+    current_cancel: Event | None = None
+    current_step_count = {"step": 0}  # mutable so the cb can update it
+    videos_total = 0
+    videos_cancelled = 0
+    videos_failed = 0
+    session_start = time.time()
+
+    async def cancel_running(reason: str) -> None:
+        nonlocal current_task, current_cancel
+        if current_task and not current_task.done():
+            logger.info("cancelling in-flight gen: req=%s reason=%s", current_request_id, reason)
+            if current_cancel is not None:
+                current_cancel.set()
+            try:
+                await asyncio.wait_for(current_task, timeout=10.0)
+            except asyncio.TimeoutError:
+                logger.warning("cancel wait timed out (req=%s)", current_request_id)
+            except Exception as e:  # noqa: BLE001
+                logger.error("cancel task error (req=%s): %s", current_request_id, e)
+        current_task = None
+        current_cancel = None
+
+    async def run_video(request_id: str, image: Image.Image, prompt: str, seed: int | None,
+                        cancel: Event) -> None:
+        """Generate video, stream frames, encode MP4. Updates outer counters."""
+        nonlocal videos_total, videos_cancelled, videos_failed
+        t0 = time.time()
+        current_step_count["step"] = 0
+
+        # Step counter via a separate callback hook that runs alongside the
+        # cancel check. We can't hand the pipeline two callbacks, so the
+        # cancel check inside the pipeline tracks step internally. Wrap
+        # is_cancelled to also bump our counter.
+        def _is_cancelled() -> bool:
+            current_step_count["step"] += 1
+            return cancel.is_set()
+
+        try:
+            frames = await asyncio.to_thread(
+                video_pipeline.generate, image, prompt, seed, _is_cancelled,
+            )
+        except Exception as e:  # noqa: BLE001
+            videos_failed += 1
+            logger.error("ltxv generate error: req=%s err=%s", request_id, e, exc_info=True)
+            await ws.send_text(json.dumps({
+                "type": "video_cancelled",
+                "requestId": request_id,
+                "atStep": current_step_count["step"],
+                "error": str(e),
+            }))
+            return
+
+        gen_ms = int((time.time() - t0) * 1000)
+
+        if frames is None:
+            videos_cancelled += 1
+            logger.info(
+                "cancelled: req=%s at_step=%d elapsed_ms=%d",
+                request_id, current_step_count["step"], gen_ms,
+            )
+            await ws.send_text(json.dumps({
+                "type": "video_cancelled",
+                "requestId": request_id,
+                "atStep": current_step_count["step"],
+            }))
+            return
+
+        # Stream each decoded frame as JPEG (text preamble + binary).
+        # Tight loop — no awaits between frames except the WS send itself.
+        for i, frame in enumerate(frames):
+            if cancel.is_set():
+                videos_cancelled += 1
+                logger.info("cancelled mid-stream: req=%s frame=%d/%d", request_id, i, len(frames))
+                await ws.send_text(json.dumps({
+                    "type": "video_cancelled",
+                    "requestId": request_id,
+                    "atStep": current_step_count["step"],
+                }))
+                return
+            buf = io.BytesIO()
+            frame.save(buf, format="JPEG", quality=config.LTXV_OUTPUT_JPEG_QUALITY)
+            await ws.send_text(json.dumps({
+                "type": "video_frame",
+                "requestId": request_id,
+                "index": i,
+                "total": len(frames),
+            }))
+            await ws.send_bytes(buf.getvalue())
+
+            if config.LTXV_DEBUG and i % 4 == 0:
+                logger.info(
+                    "frame %d/%d streamed elapsed_ms=%d",
+                    i + 1, len(frames), int((time.time() - t0) * 1000),
+                )
+
+        # Encode MP4 via the bundled ffmpeg binary. Using a subprocess
+        # rather than imageio.mimwrite() because we want explicit control
+        # over codec / pixel format / faststart for smooth iOS playback.
+        encode_t0 = time.time()
+        mp4_bytes = await asyncio.to_thread(_encode_mp4, frames, config.LTXV_FPS)
+        encode_ms = int((time.time() - encode_t0) * 1000)
+
+        videos_total += 1
+        logger.info(
+            "complete: req=%s frames=%d gen_ms=%d encode_ms=%d mp4_bytes=%d",
+            request_id, len(frames), gen_ms, encode_ms, len(mp4_bytes),
+        )
+        await ws.send_text(json.dumps({
+            "type": "video_complete",
+            "requestId": request_id,
+            "fps": config.LTXV_FPS,
+            "frames": len(frames),
+            "genMs": gen_ms,
+            "encodeMs": encode_ms,
+        }))
+        await ws.send_bytes(mp4_bytes)
+
+    try:
+        while True:
+            msg = await ws.receive()
+
+            if msg.get("type") == "websocket.disconnect":
+                break
+
+            if "text" not in msg:
+                continue
+
+            try:
+                data = json.loads(msg["text"])
+            except json.JSONDecodeError:
+                logger.warning("invalid JSON")
+                continue
+
+            mtype = data.get("type")
+
+            if mtype == "video_request":
+                # Cancel any in-flight gen first.
+                await cancel_running(reason="superseded")
+
+                request_id = str(data.get("requestId") or "")
+                prompt = str(data.get("prompt") or "")
+                seed = data.get("seed")
+                if seed is not None:
+                    try:
+                        seed = int(seed)
+                    except (TypeError, ValueError):
+                        seed = None
+
+                image_b64 = data.get("image_b64") or ""
+                try:
+                    image_bytes = base64.b64decode(image_b64)
+                    image = Image.open(io.BytesIO(image_bytes)).convert("RGB")
+                except Exception as e:  # noqa: BLE001
+                    logger.error("invalid image_b64: req=%s err=%s", request_id, e)
+                    await ws.send_text(json.dumps({
+                        "type": "video_cancelled",
+                        "requestId": request_id,
+                        "error": "invalid_image",
+                    }))
+                    continue
+
+                logger.info(
+                    "video_request: req=%s prompt='%s' image=%dx%d seed=%s",
+                    request_id, prompt[:60], image.width, image.height, seed,
+                )
+                cancel = Event()
+                current_request_id = request_id
+                current_cancel = cancel
+                current_task = asyncio.create_task(
+                    run_video(request_id, image, prompt, seed, cancel)
+                )
+
+            elif mtype == "video_cancel":
+                logger.info("video_cancel: req=%s", data.get("requestId"))
+                if current_cancel is not None:
+                    current_cancel.set()
+
+            else:
+                logger.warning("unknown message type: %s", mtype)
+
+    except WebSocketDisconnect:
+        logger.info("client disconnected: id=%d", client_id)
+    except Exception as e:  # noqa: BLE001
+        logger.error("ws handler error: %s", e, exc_info=True)
+    finally:
+        await cancel_running(reason="ws_close")
+        elapsed = time.time() - session_start
+        logger.info(
+            "session: id=%d videos_total=%d cancelled=%d failed=%d duration_s=%.1f",
+            client_id, videos_total, videos_cancelled, videos_failed, elapsed,
+        )
+
+
+def _encode_mp4(frames: list[Image.Image], fps: int) -> bytes:
+    """Encode a frame list to H.264 MP4 with faststart for smooth iOS looping.
+
+    Pipes raw RGB through the bundled ffmpeg binary — avoids tempfiles and
+    works inside the offline pod with no external ffmpeg dependency.
+    """
+    if not frames:
+        return b""
+    width, height = frames[0].size
+    ffmpeg_path = imageio_ffmpeg.get_ffmpeg_exe()
+    cmd = [
+        ffmpeg_path,
+        "-y",
+        "-loglevel", "error",
+        "-f", "rawvideo",
+        "-pix_fmt", "rgb24",
+        "-s", f"{width}x{height}",
+        "-r", str(fps),
+        "-i", "-",
+        "-c:v", "libx264",
+        "-preset", "veryfast",
+        "-crf", "23",
+        "-pix_fmt", "yuv420p",
+        "-movflags", "+faststart",
+        "-f", "mp4",
+        "pipe:1",
+    ]
+    proc = subprocess.Popen(cmd, stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    assert proc.stdin is not None and proc.stdout is not None
+    try:
+        for f in frames:
+            proc.stdin.write(f.tobytes())
+        proc.stdin.close()
+        out, err = proc.communicate(timeout=30)
+        if proc.returncode != 0:
+            raise RuntimeError(f"ffmpeg failed: rc={proc.returncode} stderr={err.decode('utf-8', 'replace')[:500]}")
+        return out
+    finally:
+        if proc.poll() is None:
+            proc.kill()
+
+
+if __name__ == "__main__":
+    uvicorn.run(
+        "video_server:app",
+        host=config.HOST,
+        port=config.PORT,
+        log_level="info",
+    )

--- a/flux-klein-server/video_server.py
+++ b/flux-klein-server/video_server.py
@@ -300,10 +300,15 @@ async def websocket_video(ws: WebSocket):
 
 
 def _encode_mp4(frames: list[Image.Image], fps: int) -> bytes:
-    """Encode a frame list to H.264 MP4 with faststart for smooth iOS looping.
+    """Encode a frame list to H.264 MP4 for iPad playback.
 
     Pipes raw RGB through the bundled ffmpeg binary — avoids tempfiles and
-    works inside the offline pod with no external ffmpeg dependency.
+    works inside the offline pod with no external ffmpeg dependency. NOTE:
+    no `-movflags +faststart` — that flag requires seekable output to
+    rewrite the moov atom at the front, and ffmpeg 7.x (in imageio-ffmpeg
+    0.6.0) refuses with "muxer does not support non seekable output" when
+    piping to stdout. Faststart only matters for HTTP streaming anyway;
+    we ship the whole MP4 to the iPad in one WS message and play from disk.
     """
     if not frames:
         return b""
@@ -322,7 +327,6 @@ def _encode_mp4(frames: list[Image.Image], fps: int) -> bytes:
         "-preset", "veryfast",
         "-crf", "23",
         "-pix_fmt", "yuv420p",
-        "-movflags", "+faststart",
         "-f", "mp4",
         "pipe:1",
     ]

--- a/ios/Kiki/App/AppCoordinator.swift
+++ b/ios/Kiki/App/AppCoordinator.swift
@@ -182,6 +182,11 @@ final class AppCoordinator {
     /// `openDrawing`/`newDrawing`, read + cleared in `navigateToGallery`.
     private var currentDrawingOpenedAt: Date?
     private(set) var streamReadiness: StreamSession.StreamReadiness = .disconnected
+
+    /// Currently-playing video MP4 temp path. Tracked so we can delete it
+    /// when the user resumes drawing (state leaves video) and avoid
+    /// littering NSTemporaryDirectory across many idle/draw cycles.
+    private var currentVideoMP4URL: URL?
     private(set) var streamFrameCount = 0
 
     // -- Stream parameters --
@@ -661,6 +666,11 @@ final class AppCoordinator {
             self.applyReadinessToResultState(readiness)
         }
 
+        session.onVideoEvent = { [weak self] event in
+            guard let self else { return }
+            self.handleVideoEvent(event)
+        }
+
         self.streamSession = session
 
         Task {
@@ -704,6 +714,12 @@ final class AppCoordinator {
         pendingStartupTransaction?.finish(status: .cancelled)
         pendingStartupTransaction = nil
         streamStartupBeganAt = nil
+        // Clean up the looping MP4 temp file (if any) so we don't leave
+        // junk in NSTemporaryDirectory across many sessions.
+        if let url = currentVideoMP4URL {
+            try? FileManager.default.removeItem(at: url)
+            currentVideoMP4URL = nil
+        }
 
         if hadSession {
             Analytics.track(.streamEnded, properties: [
@@ -762,6 +778,58 @@ final class AppCoordinator {
             return
         }
         applyReadinessToResultState(streamReadiness)
+    }
+
+    /// Map a video pod event into ResultState transitions. Overall flow:
+    ///   .streaming → .videoStreaming(latestFrame) → .videoLooping(mp4) → ...
+    /// New img2img frames automatically clobber the video state via
+    /// onImageReceived's `.streaming` set, so cancellation of an in-flight
+    /// video on resume-drawing happens implicitly. The .cancelled event
+    /// here covers the case where the pod aborted before any image
+    /// arrived (e.g. during model warmup).
+    private func handleVideoEvent(_ event: StreamWebSocketClient.VideoEvent) {
+        let prev = String(describing: resultState).prefix(40)
+        switch event {
+        case .frame(_, let imageData, let index, let total):
+            guard let frame = UIImage(data: imageData),
+                  let fallback = lastSuccessfulImage else {
+                streamLog.warning("[result] video_frame ignored (no fallback or decode failed)")
+                return
+            }
+            resultState = .videoStreaming(latestFrame: frame, fallback: fallback)
+            streamLog.info("[result] \(prev) → videoStreaming index=\(index ?? -1)/\(total ?? -1)")
+        case .complete(_, let mp4Data, _, let frames):
+            guard let fallback = lastSuccessfulImage else { return }
+            // Clean up any prior MP4 we wrote — only one in flight at a time.
+            if let prior = currentVideoMP4URL {
+                try? FileManager.default.removeItem(at: prior)
+            }
+            let url = FileManager.default.temporaryDirectory
+                .appendingPathComponent("kiki-video-\(UUID().uuidString).mp4")
+            do {
+                try mp4Data.write(to: url, options: .atomic)
+                currentVideoMP4URL = url
+                resultState = .videoLooping(mp4URL: url, fallback: fallback)
+                streamLog.info("[result] \(prev) → videoLooping bytes=\(mp4Data.count) frames=\(frames ?? -1)")
+            } catch {
+                streamLog.error("[result] mp4 write failed: \(error.localizedDescription)")
+                SentrySDK.capture(error: error) { scope in
+                    scope.setTag(value: "video.mp4_write", key: "op")
+                }
+            }
+        case .cancelled(_, let atStep, let error):
+            // If we're not currently in a video state, nothing to revert
+            // (img2img already drove us out). Otherwise pop back to
+            // .streaming on the last image.
+            if resultState.isVideo, let img = lastSuccessfulImage {
+                resultState = .streaming(image: img, frameCount: streamFrameCount)
+            }
+            if let prior = currentVideoMP4URL {
+                try? FileManager.default.removeItem(at: prior)
+                currentVideoMP4URL = nil
+            }
+            streamLog.info("[result] video_cancelled atStep=\(atStep ?? -1) err=\(error ?? "")")
+        }
     }
 
     /// Push the current config to the stream session. The capture loop will

--- a/ios/Kiki/App/AppCoordinator.swift
+++ b/ios/Kiki/App/AppCoordinator.swift
@@ -626,6 +626,13 @@ final class AppCoordinator {
             guard let self else { return }
             self.streamFrameCount += 1
             self.lastSuccessfulImage = image
+            // Resuming img2img clobbers any in-flight video state. Drop the
+            // looping MP4 from disk now — otherwise NSTemporaryDirectory
+            // accumulates one file per draw/idle cycle until stopStream.
+            if let prior = self.currentVideoMP4URL {
+                try? FileManager.default.removeItem(at: prior)
+                self.currentVideoMP4URL = nil
+            }
             self.resultState = .streaming(image: image, frameCount: self.streamFrameCount)
             if self.drawingLayout == .fullscreen {
                 self.showFloatingPanel = true

--- a/ios/Kiki/App/StreamSession.swift
+++ b/ios/Kiki/App/StreamSession.swift
@@ -38,6 +38,7 @@ final class StreamSession {
     private var captureTask: Task<Void, Never>?
     private var receiveTask: Task<Void, Never>?
     private var statusTask: Task<Void, Never>?
+    private var videoTask: Task<Void, Never>?
     private var reconnectTask: Task<Void, Never>?
 
     /// How often to capture and send frames (default ~2 FPS for FLUX.2-klein).
@@ -77,6 +78,10 @@ final class StreamSession {
 
     /// Called when a new generated image frame is received.
     var onImageReceived: ((UIImage) -> Void)?
+
+    /// Called for every event from the video pod (idle-state animation):
+    /// streamed frames, the final MP4, or a cancellation.
+    var onVideoEvent: ((StreamWebSocketClient.VideoEvent) -> Void)?
 
     /// Called when stream readiness changes.
     var onReadinessChanged: ((StreamReadiness) -> Void)?
@@ -422,6 +427,20 @@ final class StreamSession {
             }
         }
 
+        videoTask = Task { [weak self] in
+            guard let self else { return }
+            let events = await client.videoEvents
+            for await event in events {
+                guard !Task.isCancelled else { break }
+                Self.breadcrumb(category: "stream.video", message: "video event", data: [
+                    "case": String(describing: event),
+                ])
+                await MainActor.run {
+                    self.onVideoEvent?(event)
+                }
+            }
+        }
+
         statusTask = Task { [weak self] in
             guard let self else { return }
             let statuses = await client.serverStatuses
@@ -508,6 +527,8 @@ final class StreamSession {
         receiveTask = nil
         statusTask?.cancel()
         statusTask = nil
+        videoTask?.cancel()
+        videoTask = nil
         reconnectTask?.cancel()
         reconnectTask = nil
     }

--- a/ios/Kiki/App/StreamSession.swift
+++ b/ios/Kiki/App/StreamSession.swift
@@ -301,6 +301,13 @@ final class StreamSession {
         captureTask = Task.detached { [weak self] in
             Self.breadcrumb(category: "stream.lifecycle", message: "Capture loop started")
             var count = 0
+            // Tracks whether the previous tick was suppressed by the dirty
+            // check, so we breadcrumb only the idle/resume transitions
+            // (zero spam during steady-state drawing or steady-state idle).
+            // The transition to idle is the iPad-side counterpart of the
+            // image pod's `queue drained` log — together they confirm the
+            // trigger boundary.
+            var lastTickSkipped = false
             while !Task.isCancelled {
                 guard let self else { break }
 
@@ -333,12 +340,19 @@ final class StreamSession {
                         await MainActor.run { self.lastSentJpegData = jpeg }
                         count += 1
                         await self.setFramesSent(count)
+                        if lastTickSkipped {
+                            Self.breadcrumb(category: "stream.capture", message: "resumed (canvas changed)")
+                            lastTickSkipped = false
+                        }
                     } catch {
                         SentrySDK.capture(error: error) { scope in
                             scope.setTag(value: "sendFrame", key: "op")
                             scope.setExtra(value: count, key: "frameCount")
                         }
                     }
+                } else if !lastTickSkipped {
+                    Self.breadcrumb(category: "stream.capture", message: "idle (canvas unchanged)")
+                    lastTickSkipped = true
                 }
 
                 let interval = await self.captureInterval

--- a/ios/Kiki/Views/FloatingResultPanel.swift
+++ b/ios/Kiki/Views/FloatingResultPanel.swift
@@ -123,6 +123,16 @@ struct FloatingResultPanel: View {
                 Color(.systemGray6)
             }
 
+        case .videoStreaming(let latestFrame, _):
+            // Floating panel stays a still — no AVPlayerLayer here. The
+            // streamed frame already shows motion progress; falling back
+            // to the fallback if anything fails is handled by the right-pane
+            // ResultView.
+            pickableImage(latestFrame).padding(4)
+
+        case .videoLooping(_, let fallback):
+            pickableImage(fallback).padding(4)
+
         case .empty:
             Color(.systemGray6)
         }

--- a/ios/Packages/NetworkModule/Sources/NetworkModule/StreamWebSocketClient.swift
+++ b/ios/Packages/NetworkModule/Sources/NetworkModule/StreamWebSocketClient.swift
@@ -35,6 +35,16 @@ public actor StreamWebSocketClient {
         public let data: Data
     }
 
+    /// Events from the video pod path: streamed JPEG frames during
+    /// generation, the final MP4 for smooth looping, and cancellation
+    /// notices. The same correlation `requestId` propagates through every
+    /// event so the UI can match them to a specific trigger.
+    public enum VideoEvent: Sendable {
+        case frame(requestId: String?, image: Data, index: Int?, total: Int?)
+        case complete(requestId: String?, mp4: Data, fps: Int?, frames: Int?)
+        case cancelled(requestId: String?, atStep: Int?, error: String?)
+    }
+
     // MARK: - Properties
 
     private let request: URLRequest
@@ -49,6 +59,9 @@ public actor StreamWebSocketClient {
 
     private let statusContinuation: AsyncStream<ServerStatus>.Continuation
     public let serverStatuses: AsyncStream<ServerStatus>
+
+    private let videoContinuation: AsyncStream<VideoEvent>.Continuation
+    public let videoEvents: AsyncStream<VideoEvent>
 
     /// Most recent `frame_meta` from the pod, waiting to be paired with
     /// the next binary frame. Cleared each time a binary is emitted.
@@ -68,6 +81,10 @@ public actor StreamWebSocketClient {
         var statusCont: AsyncStream<ServerStatus>.Continuation!
         self.serverStatuses = AsyncStream { statusCont = $0 }
         self.statusContinuation = statusCont
+
+        var videoCont: AsyncStream<VideoEvent>.Continuation!
+        self.videoEvents = AsyncStream { videoCont = $0 }
+        self.videoContinuation = videoCont
     }
 
     // MARK: - Connection
@@ -85,6 +102,10 @@ public actor StreamWebSocketClient {
         var statusCont: AsyncStream<ServerStatus>.Continuation!
         self.serverStatuses = AsyncStream { statusCont = $0 }
         self.statusContinuation = statusCont
+
+        var videoCont: AsyncStream<VideoEvent>.Continuation!
+        self.videoEvents = AsyncStream { videoCont = $0 }
+        self.videoContinuation = videoCont
     }
 
     public func connect() async throws {
@@ -146,6 +167,7 @@ public actor StreamWebSocketClient {
         state = .disconnected
         framesContinuation.finish()
         statusContinuation.finish()
+        videoContinuation.finish()
     }
 
     // MARK: - Sending
@@ -203,7 +225,50 @@ public actor StreamWebSocketClient {
                                     ])
                                     await self.statusContinuation.yield(status)
                                 }
+                            } else if type == "video_frame_data", let b64 = json["data"] as? String,
+                                      let imageData = Data(base64Encoded: b64) {
+                                let meta = json["meta"] as? [String: Any] ?? [:]
+                                let event = StreamWebSocketClient.VideoEvent.frame(
+                                    requestId: meta["requestId"] as? String,
+                                    image: imageData,
+                                    index: meta["index"] as? Int,
+                                    total: meta["total"] as? Int
+                                )
+                                Self.breadcrumb(category: "ws.video", message: "video_frame", data: [
+                                    "bytes": imageData.count,
+                                    "index": (meta["index"] as? Int) ?? -1,
+                                    "total": (meta["total"] as? Int) ?? -1,
+                                ])
+                                await self.videoContinuation.yield(event)
+                            } else if type == "video_complete_data", let b64 = json["data"] as? String,
+                                      let mp4Data = Data(base64Encoded: b64) {
+                                let meta = json["meta"] as? [String: Any] ?? [:]
+                                let event = StreamWebSocketClient.VideoEvent.complete(
+                                    requestId: meta["requestId"] as? String,
+                                    mp4: mp4Data,
+                                    fps: meta["fps"] as? Int,
+                                    frames: meta["frames"] as? Int
+                                )
+                                Self.breadcrumb(category: "ws.video", message: "video_complete", data: [
+                                    "bytes": mp4Data.count,
+                                    "frames": (meta["frames"] as? Int) ?? -1,
+                                ])
+                                await self.videoContinuation.yield(event)
+                            } else if type == "video_cancelled" {
+                                let event = StreamWebSocketClient.VideoEvent.cancelled(
+                                    requestId: json["requestId"] as? String,
+                                    atStep: json["atStep"] as? Int,
+                                    error: json["error"] as? String
+                                )
+                                Self.breadcrumb(category: "ws.video", message: "video_cancelled", data: [
+                                    "atStep": (json["atStep"] as? Int) ?? -1,
+                                    "error": (json["error"] as? String) ?? "",
+                                ])
+                                await self.videoContinuation.yield(event)
                             }
+                            // Other types (video_frame, video_complete preambles)
+                            // are intentionally ignored — the *_data wrappers
+                            // above carry their meta as a sibling field.
                         }
 
                     @unknown default:
@@ -241,6 +306,7 @@ public actor StreamWebSocketClient {
         receiveLoopTask = nil
         framesContinuation.finish()
         statusContinuation.finish()
+        videoContinuation.finish()
     }
 
     // MARK: - Breadcrumb helper

--- a/ios/Packages/ResultModule/Sources/ResultModule/ResultState.swift
+++ b/ios/Packages/ResultModule/Sources/ResultModule/ResultState.swift
@@ -49,6 +49,13 @@ public enum ResultState {
     /// `previousImage` is displayed under a semi-transparent overlay so the
     /// user can see their last-generated image is still waiting for them.
     case idleTimeout(previousImage: UIImage?)
+    /// Pre-MP4: the video pod is streaming JPEG frames as they decode.
+    /// `latestFrame` is the most recent decoded frame; `fallback` is the
+    /// last successful still (kept around so we never blank the pane —
+    /// Constraint #2 — if anything fails mid-stream).
+    case videoStreaming(latestFrame: UIImage, fallback: UIImage)
+    /// Final state: looping the encoded MP4 from disk.
+    case videoLooping(mp4URL: URL, fallback: UIImage)
 
     public var isPreview: Bool {
         if case .preview = self { return true }
@@ -58,5 +65,12 @@ public enum ResultState {
     public var isStreaming: Bool {
         if case .streaming = self { return true }
         return false
+    }
+
+    public var isVideo: Bool {
+        switch self {
+        case .videoStreaming, .videoLooping: return true
+        default: return false
+        }
     }
 }

--- a/ios/Packages/ResultModule/Sources/ResultModule/ResultView.swift
+++ b/ios/Packages/ResultModule/Sources/ResultModule/ResultView.swift
@@ -1,3 +1,5 @@
+import AVFoundation
+import AVKit
 import SwiftUI
 
 /// Displays the generated image result with support for loading, error, and empty states.
@@ -65,6 +67,13 @@ public struct ResultView: View {
 
             case .idleTimeout(let previousImage):
                 idleTimeoutView(previousImage: previousImage)
+
+            case .videoStreaming(let latestFrame, _):
+                imageView(latestFrame)
+
+            case .videoLooping(let mp4URL, let fallback):
+                LoopingVideoView(url: mp4URL, fallback: fallback)
+                    .shadow(color: .black.opacity(0.25), radius: 12, x: 0, y: 6)
 
             }
 
@@ -518,4 +527,114 @@ public struct ResultView: View {
         message: "Server error 200: Generation timed out after 120s",
         previousImage: nil
     ))
+}
+
+// MARK: - LoopingVideoView
+
+/// AVPlayerLooper-backed seamless MP4 loop for `.videoLooping`.
+///
+/// Renders into a CALayer via AVPlayerLayer (no AVPlayerViewController
+/// chrome). Looping is via AVPlayerLooper against an AVQueuePlayer so the
+/// transition between iterations is seamless — AVPlayer's `.seekToZero`
+/// approach has a visible blink on H.264.
+///
+/// `fallback` is shown if the player item enters `.failed` (file gone,
+/// decode error). Constraint #2: never clear the right pane.
+private struct LoopingVideoView: UIViewRepresentable {
+    let url: URL
+    let fallback: UIImage
+
+    func makeCoordinator() -> Coordinator { Coordinator() }
+
+    func makeUIView(context: Context) -> PlayerContainerView {
+        let view = PlayerContainerView()
+        view.fallbackImage = fallback
+        attach(view: view, coordinator: context.coordinator)
+        return view
+    }
+
+    func updateUIView(_ view: PlayerContainerView, context: Context) {
+        view.fallbackImage = fallback
+        // If the URL changed, rebuild the player. Same URL → keep looping.
+        if context.coordinator.currentURL != url {
+            attach(view: view, coordinator: context.coordinator)
+        }
+    }
+
+    static func dismantleUIView(_ view: PlayerContainerView, coordinator: Coordinator) {
+        coordinator.player?.pause()
+        coordinator.looper = nil
+        coordinator.player = nil
+        coordinator.currentURL = nil
+    }
+
+    private func attach(view: PlayerContainerView, coordinator: Coordinator) {
+        let item = AVPlayerItem(url: url)
+        let player = AVQueuePlayer()
+        // Mute by default — the right pane is purely visual.
+        player.isMuted = true
+        coordinator.looper = AVPlayerLooper(player: player, templateItem: item)
+        coordinator.player = player
+        coordinator.currentURL = url
+        view.attach(player: player)
+        player.play()
+    }
+
+    final class Coordinator {
+        var player: AVQueuePlayer?
+        var looper: AVPlayerLooper?
+        var currentURL: URL?
+    }
+}
+
+/// UIView host for AVPlayerLayer. Falls back to a static image if the
+/// player item fails.
+final class PlayerContainerView: UIView {
+    private var playerLayer: AVPlayerLayer?
+    private let fallbackImageView = UIImageView()
+    private var failureObserver: NSKeyValueObservation?
+
+    var fallbackImage: UIImage? {
+        didSet { fallbackImageView.image = fallbackImage }
+    }
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        backgroundColor = .clear
+        fallbackImageView.contentMode = .scaleAspectFit
+        fallbackImageView.frame = bounds
+        fallbackImageView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
+        fallbackImageView.isHidden = true
+        addSubview(fallbackImageView)
+    }
+
+    required init?(coder: NSCoder) { fatalError("init(coder:) not used") }
+
+    func attach(player: AVPlayer) {
+        playerLayer?.removeFromSuperlayer()
+        let layer = AVPlayerLayer(player: player)
+        layer.videoGravity = .resizeAspect
+        layer.frame = bounds
+        self.layer.addSublayer(layer)
+        playerLayer = layer
+
+        // Watch for failure → show fallback.
+        failureObserver = player.currentItem?.observe(\.status, options: [.new]) { [weak self] item, _ in
+            guard let self else { return }
+            DispatchQueue.main.async {
+                if item.status == .failed {
+                    self.fallbackImageView.isHidden = false
+                    layer.isHidden = true
+                } else {
+                    self.fallbackImageView.isHidden = true
+                    layer.isHidden = false
+                }
+            }
+        }
+    }
+
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        playerLayer?.frame = bounds
+    }
 }

--- a/ios/Packages/ResultModule/Sources/ResultModule/ResultView.swift
+++ b/ios/Packages/ResultModule/Sources/ResultModule/ResultView.swift
@@ -1,5 +1,6 @@
 import AVFoundation
 import AVKit
+import OSLog
 import SwiftUI
 
 /// Displays the generated image result with support for loading, error, and empty states.
@@ -588,11 +589,14 @@ private struct LoopingVideoView: UIViewRepresentable {
 }
 
 /// UIView host for AVPlayerLayer. Falls back to a static image if the
-/// player item fails.
-final class PlayerContainerView: UIView {
+/// player item fails — covers KVO `.failed` (decode/asset load fails before
+/// playback) plus `failedToPlayToEndTime` and `playbackStalled` (failures
+/// after the item enters `.readyToPlay`, which the status KVO alone misses).
+private final class PlayerContainerView: UIView {
     private var playerLayer: AVPlayerLayer?
     private let fallbackImageView = UIImageView()
     private var failureObserver: NSKeyValueObservation?
+    private var notificationObservers: [NSObjectProtocol] = []
 
     var fallbackImage: UIImage? {
         didSet { fallbackImageView.image = fallbackImage }
@@ -610,31 +614,71 @@ final class PlayerContainerView: UIView {
 
     required init?(coder: NSCoder) { fatalError("init(coder:) not used") }
 
+    deinit {
+        removeNotificationObservers()
+    }
+
     func attach(player: AVPlayer) {
         playerLayer?.removeFromSuperlayer()
+        removeNotificationObservers()
+
         let layer = AVPlayerLayer(player: player)
         layer.videoGravity = .resizeAspect
         layer.frame = bounds
         self.layer.addSublayer(layer)
         playerLayer = layer
 
-        // Watch for failure → show fallback.
-        failureObserver = player.currentItem?.observe(\.status, options: [.new]) { [weak self] item, _ in
+        guard let item = player.currentItem else { return }
+
+        // KVO: catches the `.failed` transition (asset load / initial decode).
+        failureObserver = item.observe(\.status, options: [.new]) { [weak self, weak layer] item, _ in
             guard let self else { return }
             DispatchQueue.main.async {
                 if item.status == .failed {
-                    self.fallbackImageView.isHidden = false
-                    layer.isHidden = true
+                    self.showFallback(layer: layer, reason: "status=failed err=\(item.error?.localizedDescription ?? "nil")")
                 } else {
                     self.fallbackImageView.isHidden = true
-                    layer.isHidden = false
+                    layer?.isHidden = false
                 }
             }
         }
+
+        // Notifications: catch failures that happen *after* `.readyToPlay`,
+        // which KVO on `.status` doesn't observe.
+        let center = NotificationCenter.default
+        notificationObservers.append(center.addObserver(
+            forName: .AVPlayerItemFailedToPlayToEndTime,
+            object: item,
+            queue: .main
+        ) { [weak self, weak layer] note in
+            let err = note.userInfo?[AVPlayerItemFailedToPlayToEndTimeErrorKey] as? Error
+            self?.showFallback(layer: layer, reason: "failedToPlayToEndTime err=\(err?.localizedDescription ?? "nil")")
+        })
+        notificationObservers.append(center.addObserver(
+            forName: AVPlayerItem.playbackStalledNotification,
+            object: item,
+            queue: .main
+        ) { [weak self, weak layer] _ in
+            self?.showFallback(layer: layer, reason: "playbackStalled")
+        })
     }
 
     override func layoutSubviews() {
         super.layoutSubviews()
         playerLayer?.frame = bounds
     }
+
+    private func showFallback(layer: AVPlayerLayer?, reason: String) {
+        videoLog.warning("LoopingVideoView falling back: \(reason)")
+        fallbackImageView.isHidden = false
+        layer?.isHidden = true
+    }
+
+    private func removeNotificationObservers() {
+        let center = NotificationCenter.default
+        for token in notificationObservers { center.removeObserver(token) }
+        notificationObservers.removeAll()
+    }
 }
+
+private let videoLog = Logger(subsystem: "com.kiki.result", category: "video")


### PR DESCRIPTION
Two-pod architecture: image pod (FLUX, existing) + dedicated per-session video pod (LTXV i2v, new). When the user pauses drawing, the image pod's `frame_meta` emits `queueEmpty:true`; backend captures that JPEG and forwards it to the video pod, which streams ~49 decoded frames then a final MP4. iPad transitions `streaming → videoStreaming → videoLooping → streaming` (back on next sketch). Best-effort: video failures fall back silently to image-only.

Gated by `VIDEO_POD_ENABLED` (currently `true` in prod). Replaces the earlier single-pod attempt on `claude/add-drawing-animation-cWJBV`.

## Commits

- **`d6fa17a` … `ad3b386`** — initial implementation (plan, pod-side, backend, iPad UI, populate-volume LTXV download, smoke tests, feature flag).
- **`944e096`** — Round-1 review fixes: MP4 temp-file leak, `failedToPlayToEndTime` observers, `PlayerContainerView` private, drop wasted WS preambles, reaper log cleanup, `FloatingResultPanel` exhaustiveness.
- **`220bb37`** — Round-2 (live-test fixes): video pod was being killed on every iPad WS close (drawing-change navigation, network blip), forcing 3-min cold starts per drawing. Added `getOrProvisionVideoPod` mirroring `getOrProvisionPod` so video pods survive WS reconnects via Redis. Added trigger-side `video_skipped: already_in_flight` guard to prevent rapid pause-pause-pause from cancelling mid-encode.
- **`a45abdb`** — Round-3: ffmpeg pipe deadlock in `_encode_mp4`. Sequential write-stdin / read-stdout deadlocks when ffmpeg's stdout fills the 64KB pipe (any 100KB+ MP4). Symptoms: streaming arrived complete (frames 0–48), but `video_complete` never fired — `videoCompleted=0` in session_close. Switched to `communicate(input=...)` for concurrent IO. Wrapped post-streaming encode+send block in try/except so future encode failures emit `video_cancelled` (with error) instead of dying silently in the asyncio task.
- **`af3c1fa`** — `sync-flux-app.ts`: dropped RTX 4090 from GPU fallback list; hosts in EUR-NO-1 + US-IL-1 register runtime but `startSsh:true` never opens port 22 within 900s (verified 3× per DC). Falls back straight to 5090.

## Verification

- 5 of 5 DC volumes have FLUX + LTXV weights and the latest pod-side code (US-IL-1 sync still pending GPU capacity at time of writing; orchestrator's placement excluded it via `stock:none`).
- Backend deployed via `railway up` after each round.
- Manual test on iPad: image pod survives drawing changes, video pod is reused across reconnects, and on a synced DC the full `streaming → videoStreaming → videoLooping → streaming` cycle now completes.

## Known follow-ups (out of scope for this PR)

- Video pod's `selectPlacement` is independent of image pod's DC. Cross-DC trigger forward adds ~50ms; not urgent. Filing as a follow-up.
- LTXV output is 704×480; FLUX output is square — aspect ratio shifts when the loop starts. Resize follow-up.
- FP8 transformer checkpoint loaded as BF16 in VRAM (no actual FP8 inference benefit). Distilled 8-step path is what's giving the speed today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)